### PR TITLE
make `rocksdb` work with devel

### DIFF
--- a/rocksdb.nim
+++ b/rocksdb.nim
@@ -205,7 +205,7 @@ proc close*(db: var RocksDBInstance) =
   template freeField(name) =
     if db.`name`.isNil:
       `rocksdb name destroy`(db.`name`)
-      db.`name` = nil
+      db.`name` = typeof(db.`name`)(nil)
   freeField(writeOptions)
   freeField(readOptions)
   freeField(options)


### PR DESCRIPTION
The distinct types cannot accept a nil type on the devel branch, it must be explicitly written as `distinct(nil)`

ref https://github.com/nim-lang/Nim/pull/20251


  ```nim
  type Foo = distinct ptr int
  # Before:
  var x: Foo = nil
  # After:
  var x: Foo = Foo(nil)
  ```