### PR TITLE
Added support for ingesting sst files using the SstFileWriter.

### DIFF
--- a/rocksdb.nim
+++ b/rocksdb.nim
@@ -7,6 +7,6 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ./rocksdb/[backup, rocksdb, rocksiterator, transactiondb, writebatch]
+import ./rocksdb/[backup, columnfamily, rocksdb, rocksiterator, transactiondb, writebatch]
 
-export backup, rocksdb, rocksiterator, transactiondb, writebatch
+export backup, columnfamily, rocksdb, rocksiterator, transactiondb, writebatch

--- a/rocksdb.nim
+++ b/rocksdb.nim
@@ -7,6 +7,15 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ./rocksdb/[backup, columnfamily, rocksdb, rocksiterator, transactiondb, writebatch]
+import
+  ./rocksdb/[backup, columnfamily, rocksdb, rocksiterator],
+  ./rocksdb/[sstfilewriter, transactiondb, writebatch]
 
-export backup, columnfamily, rocksdb, rocksiterator, transactiondb, writebatch
+export
+  backup,
+  columnfamily,
+  rocksdb,
+  rocksiterator,
+  sstfilewriter,
+  transactiondb,
+  writebatch

--- a/rocksdb/backup.nim
+++ b/rocksdb/backup.nim
@@ -46,13 +46,14 @@ proc openBackupEngine*(
     backupOpts: backupOpts)
   ok(engine)
 
-template isClosed*(backupEngine: BackupEngineRef): bool =
+proc isClosed*(backupEngine: BackupEngineRef): bool {.inline.} =
   backupEngine.cPtr.isNil()
 
 proc createNewBackup*(
     backupEngine: BackupEngineRef,
     db: RocksDbRef): RocksDBResult[void] =
   doAssert not backupEngine.isClosed()
+  doAssert not db.isClosed()
 
   var errors: cstring
   rocksdb_backup_engine_create_new_backup(

--- a/rocksdb/backup.nim
+++ b/rocksdb/backup.nim
@@ -7,6 +7,8 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+## A BackupEngineRef is used to create and manage backups against a RocksDB database.
+
 {.push raises: [].}
 
 import
@@ -32,6 +34,8 @@ type
 proc openBackupEngine*(
     path: string,
     backupOpts = defaultBackupEngineOptions()): RocksDBResult[BackupEngineRef] =
+  ## Create a new backup engine. The path parameter is the path of the backup
+  ## directory which should be different to the path of the database.
 
   var errors: cstring
   let backupEnginePtr = rocksdb_backup_engine_open(
@@ -47,11 +51,13 @@ proc openBackupEngine*(
   ok(engine)
 
 proc isClosed*(backupEngine: BackupEngineRef): bool {.inline.} =
+  ## Returns true if the BackupEngineRef has been closed.
   backupEngine.cPtr.isNil()
 
 proc createNewBackup*(
     backupEngine: BackupEngineRef,
     db: RocksDbRef): RocksDBResult[void] =
+  ## Create a new backup of the database.
   doAssert not backupEngine.isClosed()
   doAssert not db.isClosed()
 
@@ -69,6 +75,7 @@ proc restoreDbFromLatestBackup*(
     dbDir: string,
     walDir = dbDir,
     keepLogFiles = false): RocksDBResult[void] =
+  ## Restore the database from the latest backup.
   doAssert not backupEngine.isClosed()
 
   let restoreOptions = rocksdb_restore_options_create()
@@ -88,6 +95,7 @@ proc restoreDbFromLatestBackup*(
   ok()
 
 proc close*(backupEngine: BackupEngineRef) =
+  ## Close the BackupEngineRef.
   if not backupEngine.isClosed():
     rocksdb_backup_engine_close(backupEngine.cPtr)
     backupEngine.cPtr = nil

--- a/rocksdb/backup.nim
+++ b/rocksdb/backup.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-## A BackupEngineRef is used to create and manage backups against a RocksDB database.
+## A `BackupEngineRef` is used to create and manage backups against a RocksDB database.
 
 {.push raises: [].}
 
@@ -34,8 +34,9 @@ type
 proc openBackupEngine*(
     path: string,
     backupOpts = defaultBackupEngineOptions()): RocksDBResult[BackupEngineRef] =
-  ## Create a new backup engine. The path parameter is the path of the backup
-  ## directory which should be different to the path of the database.
+  ## Create a new backup engine. The `path` parameter is the path of the backup
+  ## directory. Note that the same directory should not be used for both backups
+  ## and the database itself.
 
   var errors: cstring
   let backupEnginePtr = rocksdb_backup_engine_open(
@@ -51,7 +52,7 @@ proc openBackupEngine*(
   ok(engine)
 
 proc isClosed*(backupEngine: BackupEngineRef): bool {.inline.} =
-  ## Returns true if the BackupEngineRef has been closed.
+  ## Returns `true` if the `BackupEngineRef` has been closed.
   backupEngine.cPtr.isNil()
 
 proc createNewBackup*(
@@ -95,7 +96,7 @@ proc restoreDbFromLatestBackup*(
   ok()
 
 proc close*(backupEngine: BackupEngineRef) =
-  ## Close the BackupEngineRef.
+  ## Close the `BackupEngineRef`.
   if not backupEngine.isClosed():
     rocksdb_backup_engine_close(backupEngine.cPtr)
     backupEngine.cPtr = nil

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -23,53 +23,68 @@ type
     db: RocksDbReadWriteRef
     name: string
 
-proc withColFamily*(db: RocksDbReadOnlyRef, name: string): RocksDBResult[ColFamilyReadOnly] =
+proc withColFamily*(
+    db: RocksDbReadOnlyRef,
+    name: string): RocksDBResult[ColFamilyReadOnly] {.inline.} =
+
   # validate that the column family exists
   discard db.keyExists(@[0.byte], name).valueOr:
     return err(error)
 
   ok(ColFamilyReadOnly(db: db, name: name))
 
-proc withColFamily*(db: RocksDbReadWriteRef, name: string): RocksDBResult[ColFamilyReadWrite] =
+proc withColFamily*(
+    db: RocksDbReadWriteRef,
+    name: string): RocksDBResult[ColFamilyReadWrite] {.inline.} =
+
   # validate that the column family exists
   discard db.keyExists(@[0.byte], name).valueOr:
     return err(error)
 
   ok(ColFamilyReadWrite(db: db, name: name))
 
-proc db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto = cf.db
+proc db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto {.inline.} =
+  cf.db
 
-proc name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string = cf.name
+proc name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string {.inline.} =
+  cf.name
 
 proc get*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     key: openArray[byte],
-    onData: DataProc): RocksDBResult[bool] = cf.db.get(key, onData, cf.name)
+    onData: DataProc): RocksDBResult[bool] {.inline.} =
+  cf.db.get(key, onData, cf.name)
 
 proc get*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
-    key: openArray[byte]): RocksDBResult[seq[byte]] = cf.db.get(key, cf.name)
+    key: openArray[byte]): RocksDBResult[seq[byte]] {.inline.} =
+  cf.db.get(key, cf.name)
 
 proc put*(
     cf: ColFamilyReadWrite,
-    key, val: openArray[byte]): RocksDBResult[void] = cf.db.put(key, val, cf.name)
+    key, val: openArray[byte]): RocksDBResult[void] {.inline.} =
+  cf.db.put(key, val, cf.name)
 
 proc keyExists*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
-    key: openArray[byte]): RocksDBResult[bool] = cf.db.keyExists(key, cf.name)
+    key: openArray[byte]): RocksDBResult[bool] {.inline.} =
+  cf.db.keyExists(key, cf.name)
 
 proc delete*(
     cf: ColFamilyReadWrite,
-    key: openArray[byte]): RocksDBResult[void] = cf.db.delete(key, cf.name)
+    key: openArray[byte]): RocksDBResult[void] {.inline.} =
+  cf.db.delete(key, cf.name)
 
 proc openIterator*(
-    cf: ColFamilyReadOnly | ColFamilyReadWrite): RocksDBResult[RocksIteratorRef] =
+    cf: ColFamilyReadOnly | ColFamilyReadWrite): RocksDBResult[RocksIteratorRef] {.inline.} =
   cf.db.openIterator(cf.name)
 
-proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef =
+proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef {.inline.} =
   cf.db.openWriteBatch(cf.name)
 
-proc write*(cf: ColFamilyReadWrite, updates: WriteBatchRef): RocksDBResult[void] =
+proc write*(
+    cf: ColFamilyReadWrite,
+    updates: WriteBatchRef): RocksDBResult[void] {.inline.} =
   cf.db.write(updates)
 
 # To close the column family simply call:

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -1,0 +1,77 @@
+# Nim-RocksDB
+# Copyright 2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  ./rocksdb
+
+export rocksdb
+
+type
+  ColFamilyReadOnly* = object
+    db: RocksDbReadOnlyRef
+    name: string
+
+  ColFamilyReadWrite* = object
+    db: RocksDbReadWriteRef
+    name: string
+
+proc withColFamily*(db: RocksDbReadOnlyRef, name: string): RocksDBResult[ColFamilyReadOnly] =
+  # validate that the column family exists
+  discard db.keyExists(@[0.byte], name).valueOr:
+    return err(error)
+
+  ok(ColFamilyReadOnly(db: db, name: name))
+
+proc withColFamily*(db: RocksDbReadWriteRef, name: string): RocksDBResult[ColFamilyReadWrite] =
+  # validate that the column family exists
+  discard db.keyExists(@[0.byte], name).valueOr:
+    return err(error)
+
+  ok(ColFamilyReadWrite(db: db, name: name))
+
+proc db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto = cf.db
+
+proc name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string = cf.name
+
+proc get*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    key: openArray[byte],
+    onData: DataProc): RocksDBResult[bool] = cf.db.get(key, onData, cf.name)
+
+proc get*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    key: openArray[byte]): RocksDBResult[seq[byte]] = cf.db.get(key, cf.name)
+
+proc put*(
+    cf: ColFamilyReadWrite,
+    key, val: openArray[byte]): RocksDBResult[void] = cf.db.put(key, val, cf.name)
+
+proc keyExists*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    key: openArray[byte]): RocksDBResult[bool] = cf.db.keyExists(key, cf.name)
+
+proc delete*(
+    cf: ColFamilyReadWrite,
+    key: openArray[byte]): RocksDBResult[void] = cf.db.delete(key, cf.name)
+
+proc openIterator*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite): RocksDBResult[RocksIteratorRef] =
+  cf.db.openIterator(cf.name)
+
+proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef =
+  cf.db.openWriteBatch(cf.name)
+
+proc write*(cf: ColFamilyReadWrite, updates: WriteBatchRef): RocksDBResult[void] =
+  cf.db.write(updates)
+
+# To close the column family simply call:
+# cf.db.close()
+# which will close the underlying rocksdb instance

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -12,7 +12,7 @@
 ## types which enable writing to a specific column family without having to specify the
 ## column family in each call.
 ##
-## These column family types do not `own` the underlying `RocksDbRef` and therefore
+## These column family types do not own the underlying `RocksDbRef` and therefore
 ## to close the database, simply call `columnFamily.db.close()` which will close
 ## the underlying `RocksDbRef`. Note that doing so will effect any other column
 ## families that hold a reference to the same `RocksDbRef`.

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -14,7 +14,7 @@
 ##
 ## These column family types do not own the underlying `RocksDbRef` and therefore
 ## to close the database, simply call `columnFamily.db.close()` which will close
-## the underlying `RocksDbRef`. Note that doing so will effect any other column
+## the underlying `RocksDbRef`. Note that doing so will also impact any other column
 ## families that hold a reference to the same `RocksDbRef`.
 
 {.push raises: [].}
@@ -69,7 +69,7 @@ proc get*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     key: openArray[byte],
     onData: DataProc): RocksDBResult[bool] {.inline.} =
-  ## Gets the value of the given key from the column family using the `DataProc`
+  ## Gets the value of the given key from the column family using the `onData`
   ## callback.
   cf.db.get(key, onData, cf.name)
 
@@ -82,7 +82,7 @@ proc get*(
 proc put*(
     cf: ColFamilyReadWrite,
     key, val: openArray[byte]): RocksDBResult[void] {.inline.} =
-  ## Puts the value of the given key into the column family.
+  ## Puts a value for the given key into the column family.
   cf.db.put(key, val, cf.name)
 
 proc keyExists*(
@@ -99,7 +99,7 @@ proc delete*(
 
 proc openIterator*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite): RocksDBResult[RocksIteratorRef] {.inline.} =
-  ## Opens an iterator for the given column family.
+  ## Opens an `RocksIteratorRef` for the given column family.
   cf.db.openIterator(cf.name)
 
 proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef {.inline.} =

--- a/rocksdb/columnfamily/cfdescriptor.nim
+++ b/rocksdb/columnfamily/cfdescriptor.nim
@@ -25,20 +25,20 @@ proc initColFamilyDescriptor*(
     options = defaultColFamilyOptions()): ColFamilyDescriptor =
   ColFamilyDescriptor(name: name, options: options)
 
-template name*(descriptor: ColFamilyDescriptor): string =
+proc name*(descriptor: ColFamilyDescriptor): string {.inline.} =
   descriptor.name
 
-template options*(descriptor: ColFamilyDescriptor): ColFamilyOptionsRef =
+proc options*(descriptor: ColFamilyDescriptor): ColFamilyOptionsRef {.inline.} =
   descriptor.options
 
-template isDefault*(descriptor: ColFamilyDescriptor): bool =
+proc isDefault*(descriptor: ColFamilyDescriptor): bool {.inline.} =
   descriptor.name == DEFAULT_COLUMN_FAMILY_NAME
 
-template defaultColFamilyDescriptor*(): ColFamilyDescriptor =
+proc defaultColFamilyDescriptor*(): ColFamilyDescriptor {.inline.} =
   initColFamilyDescriptor(DEFAULT_COLUMN_FAMILY_NAME)
 
-template isClosed*(descriptor: ColFamilyDescriptor): bool =
+proc isClosed*(descriptor: ColFamilyDescriptor): bool {.inline.} =
   descriptor.options.isClosed()
 
-template close*(descriptor: ColFamilyDescriptor) =
+proc close*(descriptor: ColFamilyDescriptor) {.inline.} =
   descriptor.options.close()

--- a/rocksdb/columnfamily/cfhandle.nim
+++ b/rocksdb/columnfamily/cfhandle.nim
@@ -21,7 +21,7 @@ type
 proc newColFamilyHandle*(cPtr: ColFamilyHandlePtr): ColFamilyHandleRef =
   ColFamilyHandleRef(cPtr: cPtr)
 
-template isClosed*(handle: ColFamilyHandleRef): bool =
+proc isClosed*(handle: ColFamilyHandleRef): bool {.inline.} =
   handle.cPtr.isNil()
 
 proc cPtr*(handle: ColFamilyHandleRef): ColFamilyHandlePtr =
@@ -41,7 +41,7 @@ proc cPtr*(handle: ColFamilyHandleRef): ColFamilyHandlePtr =
 #   var nameLen: csize_t
 #   $rocksdb_column_family_handle_get_name(handle.cPtr, nameLen.addr)
 
-# template isDefault*(handle: ColFamilyHandleRef): bool =
+# proc isDefault*(handle: ColFamilyHandleRef): bool {.inline.} =
 #   handle.getName() == DEFAULT_COLUMN_FAMILY_NAME
 
 proc close*(handle: ColFamilyHandleRef) =

--- a/rocksdb/columnfamily/cfopts.nim
+++ b/rocksdb/columnfamily/cfopts.nim
@@ -21,7 +21,7 @@ type
 proc newColFamilyOptions*(): ColFamilyOptionsRef =
   ColFamilyOptionsRef(cPtr: rocksdb_options_create())
 
-template isClosed*(cfOpts: ColFamilyOptionsRef): bool =
+proc isClosed*(cfOpts: ColFamilyOptionsRef): bool {.inline.} =
   cfOpts.cPtr.isNil()
 
 proc cPtr*(cfOpts: ColFamilyOptionsRef): ColFamilyOptionsPtr =

--- a/rocksdb/internal/cftable.nim
+++ b/rocksdb/internal/cftable.nim
@@ -31,7 +31,7 @@ proc newColFamilyTable*(
 
   ColFamilyTableRef(columnFamilies: cfTable)
 
-template isClosed*(table: ColFamilyTableRef): bool =
+proc isClosed*(table: ColFamilyTableRef): bool {.inline.} =
   table.columnFamilies.isNil()
 
 proc get*(table: ColFamilyTableRef, name: string): ColFamilyHandleRef =

--- a/rocksdb/internal/utils.nim
+++ b/rocksdb/internal/utils.nim
@@ -10,9 +10,15 @@
 {.push raises: [].}
 
 import
+  std/locks,
   ../lib/librocksdb
 
 const DEFAULT_COLUMN_FAMILY_NAME* = "default"
+
+proc createLock*(): Lock =
+  var lock = Lock()
+  initLock(lock)
+  lock
 
 template bailOnErrors*(errors: cstring): auto =
   if not errors.isNil:

--- a/rocksdb/options/backupopts.nim
+++ b/rocksdb/options/backupopts.nim
@@ -21,7 +21,7 @@ type
 proc newBackupEngineOptions*(): BackupEngineOptionsRef =
   BackupEngineOptionsRef(cPtr: rocksdb_options_create())
 
-template isClosed*(engineOpts: BackupEngineOptionsRef): bool =
+proc isClosed*(engineOpts: BackupEngineOptionsRef): bool {.inline.} =
   engineOpts.cPtr.isNil()
 
 proc cPtr*(engineOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
@@ -30,7 +30,7 @@ proc cPtr*(engineOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-template defaultBackupEngineOptions*(): BackupEngineOptionsRef =
+proc defaultBackupEngineOptions*(): BackupEngineOptionsRef {.inline.} =
   newBackupEngineOptions()
   # TODO: set prefered defaults
 

--- a/rocksdb/options/dbopts.nim
+++ b/rocksdb/options/dbopts.nim
@@ -22,7 +22,7 @@ type
 proc newDbOptions*(): DbOptionsRef =
   DbOptionsRef(cPtr: rocksdb_options_create())
 
-template isClosed*(dbOpts: DbOptionsRef): bool =
+proc isClosed*(dbOpts: DbOptionsRef): bool {.inline.} =
   dbOpts.cPtr.isNil()
 
 proc cPtr*(dbOpts: DbOptionsRef): DbOptionsPtr =

--- a/rocksdb/options/readopts.nim
+++ b/rocksdb/options/readopts.nim
@@ -21,7 +21,7 @@ type
 proc newReadOptions*(): ReadOptionsRef =
   ReadOptionsRef(cPtr: rocksdb_readoptions_create())
 
-template isClosed*(readOpts: ReadOptionsRef): bool =
+proc isClosed*(readOpts: ReadOptionsRef): bool {.inline.} =
   readOpts.cPtr.isNil()
 
 proc cPtr*(readOpts: ReadOptionsRef): ReadOptionsPtr =
@@ -30,7 +30,7 @@ proc cPtr*(readOpts: ReadOptionsRef): ReadOptionsPtr =
 
 # TODO: Add setters and getters for read options properties.
 
-template defaultReadOptions*(): ReadOptionsRef =
+proc defaultReadOptions*(): ReadOptionsRef {.inline.} =
   newReadOptions()
   # TODO: set prefered defaults
 

--- a/rocksdb/options/writeopts.nim
+++ b/rocksdb/options/writeopts.nim
@@ -21,7 +21,7 @@ type
 proc newWriteOptions*(): WriteOptionsRef =
   WriteOptionsRef(cPtr: rocksdb_writeoptions_create())
 
-template isClosed*(writeOpts: WriteOptionsRef): bool =
+proc isClosed*(writeOpts: WriteOptionsRef): bool {.inline.} =
   writeOpts.cPtr.isNil()
 
 proc cPtr*(writeOpts: WriteOptionsRef): WriteOptionsPtr =
@@ -30,7 +30,7 @@ proc cPtr*(writeOpts: WriteOptionsRef): WriteOptionsPtr =
 
 # TODO: Add setters and getters for write options properties.
 
-template defaultWriteOptions*(): WriteOptionsRef =
+proc defaultWriteOptions*(): WriteOptionsRef {.inline.} =
   newWriteOptions()
   # TODO: set prefered defaults
 

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -7,6 +7,21 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+## A `RocksDBRef` represents a reference to a RocksDB instance. It can be opened
+## in read-only or read-write mode in which case a `RocksDbReadOnlyRef` or
+## `RocksDbReadWriteRef` will be returned respectively. The `RocksDbReadOnlyRef` type
+## doesn't support any of the write operations such as `put`, `delete` or `write`.
+##
+## Many of the methods of this class could potentially fail for various reasons,
+## in which case a `RocksDbResult` containing an error will be returned.
+##
+## The type wraps and holds a handle to a c pointer which needs to be freed
+## after use so `close` should be called on it to prevent a memory leak.
+##
+## Most of the procs below support passing in the name of the column family
+## which should be used for the operation. The default column family will be
+## used if no name is provided.
+
 {.push raises: [].}
 
 import
@@ -51,6 +66,13 @@ proc openRocksDb*(
     readOpts = defaultReadOptions(),
     writeOpts = defaultWriteOptions(),
     columnFamilies = @[defaultColFamilyDescriptor()]): RocksDBResult[RocksDbReadWriteRef] =
+  ## Open a RocksDB instance in read-write mode. If `columnFamilies` is empty
+  ## then it will open the default column family. If `dbOpts`, `readOpts`, or
+  ## `writeOpts` are not supplied then the default options will be used.
+  ## By default, column families will be created if they don't yet exist.
+  ## All existing column families must be specified if the database already
+  ## has previously created any. This means that the list of column families
+  ## must always at least contain the default column family.
 
   if columnFamilies.len == 0:
     return err("rocksdb: no column families")
@@ -87,6 +109,12 @@ proc openRocksDbReadOnly*(
     readOpts = defaultReadOptions(),
     columnFamilies = @[defaultColFamilyDescriptor()],
     errorIfWalFileExists = false): RocksDBResult[RocksDbReadOnlyRef] =
+  ## Open a RocksDB instance in read-only mode. If `columnFamilies` is empty
+  ## then it will open the default column family. If `dbOpts` or `readOpts` are
+  ## not supplied then the default options will be used.
+  ## By default, column families will be created if they don't yet exist.
+  ## If the database already contains any column families, then a all or
+  ## subset of the existing column families can be opened for reading.
 
   if columnFamilies.len == 0:
     return err("rocksdb: no column families")
@@ -118,9 +146,11 @@ proc openRocksDbReadOnly*(
   ok(db)
 
 proc isClosed*(db: RocksDbRef): bool {.inline.} =
+  ## Returns `true` if the database has been closed and false otherwise.
   db.cPtr.isNil()
 
 proc cPtr*(db: RocksDbRef): RocksDbPtr {.inline.} =
+  ## Get the underlying database pointer.
   doAssert not db.isClosed()
   db.cPtr
 
@@ -129,6 +159,12 @@ proc get*(
     key: openArray[byte],
     onData: DataProc,
     columnFamily = db.defaultCfName): RocksDBResult[bool] =
+  ## Get the value for the given key from the specified column family.
+  ## If the value does not exist, `false` will be returned in the result
+  ## and `onData` will not be called. If the value does exist, `true` will be
+  ## returned in the result and `onData` will be called with the value.
+  ## The `onData` callback reduces the number of copies and therefore should be
+  ## preferred if performance is required.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -162,6 +198,9 @@ proc get*(
     db: RocksDbRef,
     key: openArray[byte],
     columnFamily = db.defaultCfName): RocksDBResult[seq[byte]] =
+  ## Get the value for the given `key` from the specified column family.
+  ## If the value does not exist, an empty error will be returned in the result.
+  ## If the value does exist, the value will be returned in the result.
 
   var dataRes: RocksDBResult[seq[byte]]
   proc onData(data: openArray[byte]) =
@@ -177,6 +216,7 @@ proc put*(
     db: RocksDbReadWriteRef,
     key, val: openArray[byte],
     columnFamily = db.defaultCfName): RocksDBResult[void] =
+  ## Put the value for the given key into the specified column family.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -203,6 +243,9 @@ proc keyExists*(
     db: RocksDbRef,
     key: openArray[byte],
     columnFamily = db.defaultCfName): RocksDBResult[bool] =
+  ## Check if the key exists in the specified column family.
+  ## Returns a result containing `true` if the key exists and a result
+  ## containing `false` otherwise.
 
   # TODO: Call rocksdb_key_may_exist_cf to improve performance for the case
   # when the key does not exist
@@ -213,6 +256,9 @@ proc delete*(
     db: RocksDbReadWriteRef,
     key: openArray[byte],
     columnFamily = db.defaultCfName): RocksDBResult[void] =
+  ## Delete the value for the given `key` from the specified column family.
+  ## If the value does not exist, the delete will be a no-op.
+  ## To check if the value exists before or after a delete, use `keyExists`.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -236,6 +282,7 @@ proc delete*(
 proc openIterator*(
     db: RocksDbRef,
     columnFamily = db.defaultCfName): RocksDBResult[RocksIteratorRef] =
+  ## Open an iterator for the specified column family.
   doAssert not db.isClosed()
 
   let cfHandle  = db.cfTable.get(columnFamily)
@@ -252,6 +299,7 @@ proc openIterator*(
 proc openWriteBatch*(
     db: RocksDbReadWriteRef,
     columnFamily = db.defaultCfName): WriteBatchRef =
+  ## Open a `WriteBatchRef` which defaults to using the specified column family.
   doAssert not db.isClosed()
 
   newWriteBatch(db.cfTable, columnFamily)
@@ -259,6 +307,7 @@ proc openWriteBatch*(
 proc write*(
     db: RocksDbReadWriteRef,
     updates: WriteBatchRef): RocksDBResult[void] =
+  ## Apply the updates in the `WriteBatchRef` to the database.
   doAssert not db.isClosed()
 
   var errors: cstring
@@ -272,6 +321,10 @@ proc write*(
   ok()
 
 proc close*(db: RocksDbRef) =
+  ## Close the `RocksDbRef` which will release the connection to the database
+  ## and free the memory associated with it. Close is idempotent and can safely
+  ## be called multple times. Close is a no-op if the RocksDbRef is already closed.
+
   withLock(db.lock):
     if not db.isClosed():
       db.dbOpts.close()

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -25,7 +25,8 @@ export
   readopts,
   writeopts,
   cfdescriptor,
-  rocksiterator
+  rocksiterator,
+  writebatch
 
 type
   RocksDbPtr* = ptr rocksdb_t
@@ -119,13 +120,6 @@ template isClosed*(db: RocksDbRef): bool =
 proc cPtr*(db: RocksDbRef): RocksDbPtr =
   doAssert not db.isClosed()
   db.cPtr
-
-proc withDefaultColFamily*(db: RocksDbRef | RocksDbReadWriteRef, name: string): auto =
-  db.defaultCfName = name
-  db
-
-proc defaultColFamily*(db: RocksDbRef): string =
-  db.defaultCfName
 
 proc get*(
     db: RocksDbRef,

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -31,7 +31,7 @@ proc newRocksIterator*(cPtr: RocksIteratorPtr): RocksIteratorRef =
   RocksIteratorRef(cPtr: cPtr)
 
 proc isClosed*(iter: RocksIteratorRef): bool {.inline.} =
-  ## Returns `true` if the iterator is closed.
+  ## Returns `true` if the iterator is closed and `false` otherwise.
   iter.cPtr.isNil()
 
 proc seekToFirst*(iter: RocksIteratorRef) =
@@ -45,7 +45,7 @@ proc seekToLast*(iter: RocksIteratorRef) =
   rocksdb_iter_seek_to_last(iter.cPtr)
 
 proc isValid*(iter: RocksIteratorRef): bool =
-  ## Returns `true` if the iterator is valid.
+  ## Returns `true` if the iterator is valid and `false` otherwise.
   rocksdb_iter_valid(iter.cPtr).bool
 
 proc next*(iter: RocksIteratorRef) =

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -27,7 +27,7 @@ proc newRocksIterator*(cPtr: RocksIteratorPtr): RocksIteratorRef =
   doAssert not cPtr.isNil()
   RocksIteratorRef(cPtr: cPtr)
 
-template isClosed*(iter: RocksIteratorRef): bool =
+proc isClosed*(iter: RocksIteratorRef): bool {.inline.} =
   iter.cPtr.isNil()
 
 proc seekToFirst*(iter: RocksIteratorRef) =

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -30,7 +30,9 @@ type
     envOptsPtr: EnvOptionsPtr
     dbOpts: DbOptionsRef
 
-proc openSstFileWriter*(filePath: string, dbOpts = defaultDbOptions()): RocksDBResult[SstFileWriterRef] =
+proc openSstFileWriter*(
+    filePath: string,
+    dbOpts = defaultDbOptions()): RocksDBResult[SstFileWriterRef] =
   ## Creates a new `SstFileWriterRef` and opens the file at the given `filePath`.
   doAssert not dbOpts.isClosed()
 

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -7,8 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-## A `RocksIteratorRef` is a reference to a RocksDB iterator which supports
-## iterating over the key value pairs in a column family.
+## A `SstFileWriterRef` is used to create sst files that can be added to the database later.
 
 {.push raises: [].}
 
@@ -52,7 +51,7 @@ proc openSstFileWriter*(
   ok(writer)
 
 proc isClosed*(writer: SstFileWriterRef): bool {.inline.} =
-  ## Returns `true` if the `SstFileWriterRef` is closed.
+  ## Returns `true` if the `SstFileWriterRef` is closed and `false` otherwise.
   writer.cPtr.isNil()
 
 proc put*(
@@ -84,7 +83,7 @@ proc delete*(writer: SstFileWriterRef, key: openArray[byte]): RocksDBResult[void
   ok()
 
 proc finish*(writer: SstFileWriterRef): RocksDBResult[void] =
-  ## Finish the sst file.
+  ## Finish the process and close the sst file.
   doAssert not writer.isClosed()
 
   var errors: cstring

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -1,0 +1,100 @@
+# Nim-RocksDB
+# Copyright 2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## A `RocksIteratorRef` is a reference to a RocksDB iterator which supports
+## iterating over the key value pairs in a column family.
+
+{.push raises: [].}
+
+import
+  ./lib/librocksdb,
+  ./internal/utils,
+  ./options/dbopts,
+  ./rocksresult
+
+export
+  rocksresult
+
+type
+  SstFileWriterPtr* = ptr rocksdb_sstfilewriter_t
+  EnvOptionsPtr = ptr rocksdb_envoptions_t
+
+  SstFileWriterRef* = ref object
+    cPtr: SstFileWriterPtr
+    envOptsPtr: EnvOptionsPtr
+    dbOpts: DbOptionsRef
+
+proc openSstFileWriter*(filePath: string, dbOpts = defaultDbOptions()): RocksDBResult[SstFileWriterRef] =
+  ## Creates a new `SstFileWriterRef` and opens the file at the given `filePath`.
+  doAssert not dbOpts.isClosed()
+
+  let envOptsPtr = rocksdb_envoptions_create()
+  let writer = SstFileWriterRef(
+    cPtr: rocksdb_sstfilewriter_create(envOptsPtr, dbOpts.cPtr),
+    envOptsPtr: envOptsPtr,
+    dbOpts: dbOpts)
+
+  var errors: cstring
+  rocksdb_sstfilewriter_open(
+      writer.cPtr,
+      filePath.cstring,
+      cast[cstringArray](errors.addr))
+  bailOnErrors(errors)
+
+  ok(writer)
+
+proc isClosed*(writer: SstFileWriterRef): bool {.inline.} =
+  ## Returns `true` if the `SstFileWriterRef` is closed.
+  writer.cPtr.isNil()
+
+proc put*(
+    writer: SstFileWriterRef,
+    key: openArray[byte],
+    val: openArray[byte]): RocksDBResult[void] =
+  ## Add a key-value pair to the sst file.
+
+  var errors: cstring
+  rocksdb_sstfilewriter_put(
+      writer.cPtr,
+      cast[cstring](unsafeAddr key[0]), csize_t(key.len),
+      cast[cstring](unsafeAddr val[0]), csize_t(val.len),
+      cast[cstringArray](errors.addr))
+  bailOnErrors(errors)
+
+  ok()
+
+proc delete*(writer: SstFileWriterRef, key: openArray[byte]): RocksDBResult[void] =
+  ## Delete a key-value pair from the sst file.
+
+  var errors: cstring
+  rocksdb_sstfilewriter_delete(
+      writer.cPtr,
+      cast[cstring](unsafeAddr key[0]), csize_t(key.len),
+      cast[cstringArray](errors.addr))
+  bailOnErrors(errors)
+
+  ok()
+
+proc finish*(writer: SstFileWriterRef): RocksDBResult[void] =
+  ## Finish the sst file.
+  doAssert not writer.isClosed()
+
+  var errors: cstring
+  rocksdb_sstfilewriter_finish(writer.cPtr, cast[cstringArray](errors.addr))
+  bailOnErrors(errors)
+
+  ok()
+
+proc close*(writer: SstFileWriterRef) =
+  ## Closes the `SstFileWriterRef`.
+  if not writer.isClosed():
+    rocksdb_envoptions_destroy(writer.envOptsPtr)
+    writer.envOptsPtr = nil
+    rocksdb_sstfilewriter_destroy(writer.cPtr)
+    writer.cPtr = nil

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -7,6 +7,12 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+## A `TransactionDbRef` can be used to open a connection to the RocksDB database
+## with support for transactional operations against multiple column families.
+## To create a new transaction call `beginTransaction` which will return a
+## `TransactionRef`. To commit or rollback the transaction call `commit` or
+## `rollback` on the `TransactionRef` type after applying changes to the transaction.
+
 {.push raises: [].}
 
 import
@@ -44,6 +50,9 @@ proc openTransactionDb*(
     dbOpts = defaultDbOptions(),
     txDbOpts = defaultTransactionDbOptions(),
     columnFamilies = @[defaultColFamilyDescriptor()]): RocksDBResult[TransactionDbRef] =
+  ## Open a `TransactionDbRef` with the given options and column families.
+  ## If no column families are provided the default column family will be used.
+  ## If no options are provided the default options will be used.
 
   if columnFamilies.len == 0:
     return err("rocksdb: no column families")
@@ -75,6 +84,7 @@ proc openTransactionDb*(
   ok(db)
 
 proc isClosed*(db: TransactionDbRef): bool {.inline.} =
+  ## Returns `true` if the `TransactionDbRef` has been closed.
   db.cPtr.isNil()
 
 proc beginTransaction*(
@@ -83,6 +93,9 @@ proc beginTransaction*(
     writeOpts = defaultWriteOptions(),
     txOpts = defaultTransactionOptions(),
     columnFamily = DEFAULT_COLUMN_FAMILY_NAME): TransactionRef =
+  ## Begin a new transaction against the database. The transaction will default
+  ## to using the specified column family. If no column family is specified
+  ## then the default column family will be used.
   doAssert not db.isClosed()
 
   let txPtr = rocksdb_transaction_begin(
@@ -94,6 +107,7 @@ proc beginTransaction*(
   newTransaction(txPtr, readOpts, writeOpts, txOpts, columnFamily, db.cfTable)
 
 proc close*(db: TransactionDbRef) =
+  ## Close the `TransactionDbRef`.
   withLock(db.lock):
     if not db.isClosed():
       db.dbOpts.close()

--- a/rocksdb/transactions/transaction.nim
+++ b/rocksdb/transactions/transaction.nim
@@ -50,13 +50,6 @@ proc newTransaction*(
 template isClosed*(tx: TransactionRef): bool =
   tx.cPtr.isNil()
 
-proc withDefaultColFamily*(tx: TransactionRef, name: string): TransactionRef =
-  tx.defaultCfName = name
-  tx
-
-proc defaultColFamily*(tx: TransactionRef): string =
-  tx.defaultCfName
-
 proc get*(
     tx: TransactionRef,
     key: openArray[byte],

--- a/rocksdb/transactions/transaction.nim
+++ b/rocksdb/transactions/transaction.nim
@@ -7,12 +7,21 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+## To use transactions, you must first create a `TransactionDbRef`. Then to
+## create a transaction call `beginTransaction` on the `TransactionDbRef`.
+## `commit` and `rollback` are used to commit or rollback a transaction.
+## The `TransactionDbRef` currently supports `put`, `delete` and `get` operations.
+## Keys that have been writen to a transaction but are not yet committed can be
+## read from the transaction using `get`. Uncommitted updates will not be visible
+## to other transactions until they are committed to the database.
+## Multiple column families can be written to and read from in a single transaction
+## but a default column family will be used if none is specified in each call.
+
 {.push raises: [].}
 
 import
   ../lib/librocksdb,
-  ../options/[dbopts, readopts, writeopts],
-  ../columnfamily/[cfopts, cfdescriptor, cfhandle],
+  ../options/[readopts, writeopts],
   ../internal/[cftable, utils],
   ../rocksresult,
   ./txopts
@@ -48,6 +57,7 @@ proc newTransaction*(
       cfTable: cfTable)
 
 proc isClosed*(tx: TransactionRef): bool {.inline.} =
+  ## Returns `true` if the `TransactionRef` has been closed.
   tx.cPtr.isNil()
 
 proc get*(
@@ -55,6 +65,8 @@ proc get*(
     key: openArray[byte],
     onData: DataProc,
     columnFamily = tx.defaultCfName): RocksDBResult[bool] =
+  ## Get the value for a given key from the transaction using the provided
+  ## `onData` callback.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -88,6 +100,7 @@ proc get*(
     tx: TransactionRef,
     key: openArray[byte],
     columnFamily = tx.defaultCfName): RocksDBResult[seq[byte]] =
+  ## Get the value for a given key from the transaction.
 
   var dataRes: RocksDBResult[seq[byte]]
   proc onData(data: openArray[byte]) =
@@ -103,6 +116,7 @@ proc put*(
     tx: TransactionRef,
     key, val: openArray[byte],
     columnFamily = tx.defaultCfName): RocksDBResult[void] =
+  ## Put the value for the given key into the transaction.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -128,6 +142,7 @@ proc delete*(
     tx: TransactionRef,
     key: openArray[byte],
     columnFamily = tx.defaultCfName): RocksDBResult[void] =
+  ## Delete the value for the given key from the transaction.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -148,6 +163,7 @@ proc delete*(
   ok()
 
 proc commit*(tx: TransactionRef): RocksDBResult[void] =
+  ## Commit the transaction.
   doAssert not tx.isClosed()
 
   var errors: cstring
@@ -157,6 +173,7 @@ proc commit*(tx: TransactionRef): RocksDBResult[void] =
   ok()
 
 proc rollback*(tx: TransactionRef): RocksDBResult[void] =
+  ## Rollback the transaction.
   doAssert not tx.isClosed()
 
   var errors: cstring
@@ -166,6 +183,7 @@ proc rollback*(tx: TransactionRef): RocksDBResult[void] =
   ok()
 
 proc close*(tx: TransactionRef) =
+  ## Close the `TransactionRef`.
   if not tx.isClosed():
     tx.readOpts.close()
     tx.writeOpts.close()

--- a/rocksdb/transactions/transaction.nim
+++ b/rocksdb/transactions/transaction.nim
@@ -47,7 +47,7 @@ proc newTransaction*(
       defaultCfName: defaultCfName,
       cfTable: cfTable)
 
-template isClosed*(tx: TransactionRef): bool =
+proc isClosed*(tx: TransactionRef): bool {.inline.} =
   tx.cPtr.isNil()
 
 proc get*(

--- a/rocksdb/transactions/txdbopts.nim
+++ b/rocksdb/transactions/txdbopts.nim
@@ -21,7 +21,7 @@ type
 proc newTransactionDbOptions*(): TransactionDbOptionsRef =
   TransactionDbOptionsRef(cPtr: rocksdb_transactiondb_options_create())
 
-template isClosed*(txDbOpts: TransactionDbOptionsRef): bool =
+proc isClosed*(txDbOpts: TransactionDbOptionsRef): bool {.inline.} =
   txDbOpts.cPtr.isNil()
 
 proc cPtr*(txDbOpts: TransactionDbOptionsRef): TransactionDbOptionsPtr =
@@ -30,7 +30,7 @@ proc cPtr*(txDbOpts: TransactionDbOptionsRef): TransactionDbOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-template defaultTransactionDbOptions*(): TransactionDbOptionsRef =
+proc defaultTransactionDbOptions*(): TransactionDbOptionsRef {.inline.} =
   newTransactionDbOptions()
   # TODO: set prefered defaults
 

--- a/rocksdb/transactions/txopts.nim
+++ b/rocksdb/transactions/txopts.nim
@@ -21,7 +21,7 @@ type
 proc newTransactionOptions*(): TransactionOptionsRef =
   TransactionOptionsRef(cPtr: rocksdb_transaction_options_create())
 
-template isClosed*(txOpts: TransactionOptionsRef): bool =
+proc isClosed*(txOpts: TransactionOptionsRef): bool {.inline.} =
   txOpts.cPtr.isNil()
 
 proc cPtr*(txOpts: TransactionOptionsRef): TransactionOptionsPtr =
@@ -30,7 +30,7 @@ proc cPtr*(txOpts: TransactionOptionsRef): TransactionOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-template defaultTransactionOptions*(): TransactionOptionsRef =
+proc defaultTransactionOptions*(): TransactionOptionsRef {.inline.} =
   newTransactionOptions()
   # TODO: set prefered defaults
 

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -31,7 +31,7 @@ proc newWriteBatch*(cfTable: ColFamilyTableRef, defaultCfName: string): WriteBat
     defaultCfName: defaultCfName,
     cfTable: cfTable)
 
-template isClosed*(batch: WriteBatchRef): bool =
+proc isClosed*(batch: WriteBatchRef): bool {.inline.} =
   batch.cPtr.isNil()
 
 proc cPtr*(batch: WriteBatchRef): WriteBatchPtr =

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -7,6 +7,8 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+## A `WriteBatchRef` holds a collection of updates to apply atomically to a `RocksDbRef`.
+
 {.push raises: [].}
 
 import
@@ -32,17 +34,21 @@ proc newWriteBatch*(cfTable: ColFamilyTableRef, defaultCfName: string): WriteBat
     cfTable: cfTable)
 
 proc isClosed*(batch: WriteBatchRef): bool {.inline.} =
+  ## Returns `true` if the `WriteBatchRef` has been closed.
   batch.cPtr.isNil()
 
 proc cPtr*(batch: WriteBatchRef): WriteBatchPtr =
+  ## Get the underlying database pointer.
   doAssert not batch.isClosed()
   batch.cPtr
 
 proc clear*(batch: WriteBatchRef) =
+  ## Clears the write batch.
   doAssert not batch.isClosed()
   rocksdb_writebatch_clear(batch.cPtr)
 
 proc count*(batch: WriteBatchRef): int =
+  ## Get the number of updates in the write batch.
   doAssert not batch.isClosed()
   rocksdb_writebatch_count(batch.cPtr).int
 
@@ -50,6 +56,7 @@ proc put*(
     batch: WriteBatchRef,
     key, val: openArray[byte],
     columnFamily = DEFAULT_COLUMN_FAMILY_NAME): RocksDBResult[void] =
+  ## Add a put operation to the write batch.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -72,6 +79,7 @@ proc delete*(
     batch: WriteBatchRef,
     key: openArray[byte],
     columnFamily = DEFAULT_COLUMN_FAMILY_NAME): RocksDBResult[void] =
+  ## Add a delete operation to the write batch.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
@@ -89,6 +97,7 @@ proc delete*(
   ok()
 
 proc close*(batch: WriteBatchRef) =
+  ## Close the `WriteBatchRef`.
   if not batch.isClosed():
     rocksdb_writebatch_destroy(batch.cPtr)
     batch.cPtr = nil

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -7,7 +7,7 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-## A `WriteBatchRef` holds a collection of updates to apply atomically to a `RocksDbRef`.
+## A `WriteBatchRef` holds a collection of updates to apply atomically to the database.
 
 {.push raises: [].}
 
@@ -34,7 +34,7 @@ proc newWriteBatch*(cfTable: ColFamilyTableRef, defaultCfName: string): WriteBat
     cfTable: cfTable)
 
 proc isClosed*(batch: WriteBatchRef): bool {.inline.} =
-  ## Returns `true` if the `WriteBatchRef` has been closed.
+  ## Returns `true` if the `WriteBatchRef` has been closed and `false` otherwise.
   batch.cPtr.isNil()
 
 proc cPtr*(batch: WriteBatchRef): WriteBatchPtr =

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -20,6 +20,7 @@ import
   ./transactions/test_txdbopts,
   ./transactions/test_txopts,
   ./test_backup,
+  ./test_columnfamily,
   ./test_rocksdb,
   ./test_rocksiterator,
   ./test_writebatch

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -23,4 +23,5 @@ import
   ./test_columnfamily,
   ./test_rocksdb,
   ./test_rocksiterator,
+  ./test_sstfilewriter,
   ./test_writebatch

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -1,0 +1,84 @@
+# Nim-RocksDB
+# Copyright 2018-2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  std/os,
+  tempfile,
+  unittest2,
+  ../rocksdb/columnfamily,
+  ./test_helper
+
+suite "ColFamily Tests":
+  const
+    CF_DEFAULT = "default"
+    CF_OTHER = "other"
+
+  let
+    key = @[byte(1), 2, 3, 4, 5]
+    otherKey = @[byte(1), 2, 3, 4, 5, 6]
+    val = @[byte(1), 2, 3, 4, 5]
+
+  setup:
+    let
+      dbPath = mkdtemp() / "data"
+      db = initReadWriteDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+
+  teardown:
+    db.close()
+    removeDir($dbPath)
+
+  test "Basic operations":
+    let r0 = db.withColFamily(CF_OTHER)
+    check r0.isOk()
+    let cf = r0.value()
+
+    check cf.put(key, val).isOk()
+
+    var bytes: seq[byte]
+    check cf.get(key, proc(data: openArray[byte]) = bytes = @data)[]
+    check not cf.get(otherkey, proc(data: openArray[byte]) = bytes = @data)[]
+
+    var r1 = cf.get(key)
+    check r1.isOk() and r1.value == val
+
+    var r2 = cf.get(otherKey)
+    # there's no error string for missing keys
+    check r2.isOk() == false and r2.error.len == 0
+
+    var e1 = cf.keyExists(key)
+    check e1.isOk() and e1.value == true
+
+    var e2 = cf.keyExists(otherKey)
+    check e2.isOk() and e2.value == false
+
+    var d = cf.delete(key)
+    check d.isOk()
+
+    e1 = cf.keyExists(key)
+    check e1.isOk() and e1.value == false
+
+    d = cf.delete(otherKey)
+    check d.isOk()
+
+    cf.db.close()
+    check db.isClosed()
+
+    # Open database in read only mode
+    block:
+      var res = initReadOnlyDb(dbPath).withColFamily(CF_DEFAULT)
+      check res.isOk()
+
+      let readOnlyCf = res.value()
+      let r = readOnlyCf.keyExists(key)
+      check r.isOk() and r.value == false
+
+      readOnlyCf.db.close()
+      check readOnlyCf.db.isClosed()

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -215,14 +215,6 @@ suite "RocksDbRef Tests":
     let r4 = db.delete(key, CF_UNKNOWN)
     check r4.isErr() and r4.error() == "rocksdb: unknown column family"
 
-  test "Test withDefaultColFamily":
-    discard db.withDefaultColFamily(CF_OTHER)
-
-    check:
-      db.put(key, val).isOk()
-      not db.keyExists(key, CF_DEFAULT).get()
-      db.keyExists(key, CF_OTHER).get()
-
   test "Test missing key and values":
     let
       key1 = @[byte(1)] # exists with non empty value

--- a/tests/test_sstfilewriter.nim
+++ b/tests/test_sstfilewriter.nim
@@ -1,0 +1,91 @@
+# Nim-RocksDB
+# Copyright 2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  std/os,
+  tempfile,
+  unittest2,
+  ../rocksdb/[rocksdb, sstfilewriter],
+  ./test_helper
+
+suite "SstFileWriterRef Tests":
+
+  const
+    CF_DEFAULT = "default"
+    CF_OTHER = "other"
+
+  let
+    key1 = @[byte(1)]
+    val1 = @[byte(1)]
+    key2 = @[byte(2)]
+    val2 = @[byte(2)]
+    key3 = @[byte(3)]
+    val3 = @[byte(3)]
+
+  setup:
+    let
+      dbPath = mkdtemp() / "data"
+      sstFilePath = mkdtemp() / "sst"
+      db = initReadWriteDb(dbPath,
+        columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+
+  teardown:
+    db.close()
+    removeDir($dbPath)
+
+  test "Write to sst file then load into db using default column family":
+    let res = openSstFileWriter(sstFilePath)
+    check res.isOk()
+    let writer = res.get()
+    defer: writer.close()
+
+    check:
+      writer.put(key1, val1).isOk()
+      writer.put(key2, val2).isOk()
+      writer.put(key3, val3).isOk()
+      writer.delete(@[byte(4)]).isOk()
+      writer.finish().isOk()
+
+      db.ingestExternalFile(sstFilePath).isOk()
+      db.get(key1).get() == val1
+      db.get(key2).get() == val2
+      db.get(key3).get() == val3
+
+  test "Write to sst file then load into db using specific column family":
+    let res = openSstFileWriter(sstFilePath)
+    check res.isOk()
+    let writer = res.get()
+    defer: writer.close()
+
+    check:
+      writer.put(key1, val1).isOk()
+      writer.put(key2, val2).isOk()
+      writer.put(key3, val3).isOk()
+      writer.finish().isOk()
+
+      db.ingestExternalFile(sstFilePath, CF_OTHER).isOk()
+      db.keyExists(key1, CF_DEFAULT).get() == false
+      db.keyExists(key2, CF_DEFAULT).get() == false
+      db.keyExists(key3, CF_DEFAULT).get() == false
+      db.get(key1, CF_OTHER).get() == val1
+      db.get(key2, CF_OTHER).get() == val2
+      db.get(key3, CF_OTHER).get() == val3
+
+  test "Test close":
+    let res = openSstFileWriter(sstFilePath)
+    check res.isOk()
+    let writer = res.get()
+
+    check not writer.isClosed()
+    writer.close()
+    check writer.isClosed()
+    writer.close()
+    check writer.isClosed()


### PR DESCRIPTION
This PR includes the following changes:
- Added support for ingesting sst files using the SstFileWriter.
- Added API documentation.
- Added a new ColumnFamily type which supports writing to a specific column family. Multiple column family instances can be created all using a single instance of the database.
- Added lock to close in TransactionDbRef and RocksDbRef in order to support close calls from multiple threads.

