### PR TITLE
Support for static linking RocksDb.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          # - os: linux
-          #   cpu: amd64
+          - os: linux
+            cpu: amd64
           # - os: linux
           #   cpu: i386
-          # - os: macos
-          #   cpu: amd64
+          - os: macos
+            cpu: amd64
           - os: windows
             cpu: amd64
           #- os: windows
             #cpu: i386
-        # branch: [version-1-6, version-2-0, devel]
-        branch: [version-1-6]
+        branch: [version-1-6, version-2-0, devel]
         include:
           - target:
               os: linux
@@ -147,7 +146,7 @@ jobs:
         run: |
           export VCPKG_LIBRARY_LINKAGE=static
           export VCPKG_BUILD_TYPE=release
-          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-windows-static-release
+          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-windows-static
 
           LIBS_DIR=build/lib/
           mkdir -p ${LIBS_DIR}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           export VCPKG_LIBRARY_LINKAGE=static
           export VCPKG_BUILD_TYPE=release
-          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]
+          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-mingw-static
 
           LIBS_DIR=build/lib/
           mkdir -p ${LIBS_DIR}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,6 @@ jobs:
         if: >
           runner.os == 'Windows'
         run: |
-          /c/vcpkg/vcpkg --help
           export VCPKG_LIBRARY_LINKAGE=static
           export VCPKG_BUILD_TYPE=release
           /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]
@@ -155,6 +154,9 @@ jobs:
           cp /c/vcpkg/packages/lz4_x64-windows/lib/lz4.lib ${LIBS_DIR}
           cp /c/vcpkg/packages/zstd_x64-windows/lib/zstd.lib ${LIBS_DIR}
           cp /c/vcpkg/packages/rocksdb_x64-windows/lib/rocksdb.lib ${LIBS_DIR}
+
+          pwd
+          ls -al ${LIBS_DIR}
 
 
       - name: Path to cached dependencies (Windows)
@@ -205,6 +207,10 @@ jobs:
             # https://github.com/status-im/nimbus-eth2/issues/3121
             export NIMFLAGS="-d:nimRawSetjmp"
           fi
+
+          pwd
+          ls -al
+          ls build/lib/
           nim --version
           nimble --version
           nimble install -y --depsOnly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,20 +140,6 @@ jobs:
           7z x -y external/nimbus-deps.zip
           cp -a "./${ROCKSDBSUB}/librocksdb.dll" "${DLLPATH}/librocksdb.dll"
 
-      - name: Install static dependencies (Windows)
-        if: >
-          runner.os == 'Windows'
-        run: |
-          export VCPKG_LIBRARY_LINKAGE=static
-          export VCPKG_BUILD_TYPE=release
-          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-windows-static
-
-          LIBS_DIR=build/lib/
-          mkdir -p ${LIBS_DIR}
-          cp /c/vcpkg/packages/lz4_x64-windows/lib/lz4.lib ${LIBS_DIR}
-          cp /c/vcpkg/packages/zstd_x64-windows/lib/zstd.lib ${LIBS_DIR}
-          cp /c/vcpkg/packages/rocksdb_x64-windows/lib/rocksdb.lib ${LIBS_DIR}
-
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
@@ -207,4 +193,8 @@ jobs:
           nimble --version
           nimble install -y --depsOnly
           nimble test
-          nimble test_static
+
+          # static linking is not supported on windows
+          if [[ "${{ matrix.target.os }}" != "windows" ]]; then
+            nimble test_static
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           export VCPKG_LIBRARY_LINKAGE=static
           export VCPKG_BUILD_TYPE=release
-          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-mingw-static
+          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]:x64-windows-static-release
 
           LIBS_DIR=build/lib/
           mkdir -p ${LIBS_DIR}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          # - os: linux
-          #   cpu: amd64
+          - os: linux
+            cpu: amd64
           # - os: linux
           #   cpu: i386
           - os: macos
             cpu: amd64
-          # - os: windows
-          #   cpu: amd64
+          - os: windows
+            cpu: amd64
           #- os: windows
             #cpu: i386
-        # branch: [version-1-6, version-2-0, devel]
-        branch: [version-1-6]
+        branch: [version-1-6, version-2-0, devel]
         include:
           - target:
               os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - os: linux
-            cpu: amd64
-          - os: linux
-            cpu: i386
+          # - os: linux
+          #   cpu: amd64
+          # - os: linux
+          #   cpu: i386
           - os: macos
             cpu: amd64
-          - os: windows
-            cpu: amd64
+          # - os: windows
+          #   cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-6, version-2-0, devel]
+        # branch: [version-1-6, version-2-0, devel]
+        branch: [version-1-6]
         include:
           - target:
               os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - os: linux
-            cpu: amd64
+          # - os: linux
+          #   cpu: amd64
           # - os: linux
           #   cpu: i386
-          - os: macos
-            cpu: amd64
+          # - os: macos
+          #   cpu: amd64
           - os: windows
             cpu: amd64
           #- os: windows
@@ -139,6 +139,18 @@ jobs:
           curl -L "https://github.com/status-im/nimbus-deps/releases/download/nimbus-deps/nimbus-deps.zip" -o external/nimbus-deps.zip
           7z x -y external/nimbus-deps.zip
           cp -a "./${ROCKSDBSUB}/librocksdb.dll" "${DLLPATH}/librocksdb.dll"
+
+      - name: Install static dependencies (Windows)
+        if: >
+          runner.os == 'Windows'
+        run: |
+          pwd
+          export VCPKG_LIBRARY_LINKAGE=static
+          echo $VCPKG_LIBRARY_LINKAGE
+          /vcpkg install rocksdb[core,lz4,zstd]
+
+          # mkdir build dir
+          # copy static deps
 
       - name: Path to cached dependencies (Windows)
         if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
             cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-6, version-2-0, devel]
+        # branch: [version-1-6, version-2-0, devel]
+        branch: [version-1-6]
         include:
           - target:
               os: linux
@@ -144,14 +145,9 @@ jobs:
         if: >
           runner.os == 'Windows'
         run: |
-          pwd
-          ls /c/
-          ls /d/
-          ls /d/a/
-          /c/vcpkg --help
+          /c/vcpkg/vcpkg --help
           export VCPKG_LIBRARY_LINKAGE=static
-
-          #/vcpkg install rocksdb[core,lz4,zstd]
+          /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]
           # mkdir build dir
           # copy static deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             shell: bash
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-latest
             shell: msys2 {0}
 
     defaults:
@@ -155,10 +155,6 @@ jobs:
           cp /c/vcpkg/packages/zstd_x64-windows/lib/zstd.lib ${LIBS_DIR}
           cp /c/vcpkg/packages/rocksdb_x64-windows/lib/rocksdb.lib ${LIBS_DIR}
 
-          pwd
-          ls -al ${LIBS_DIR}
-
-
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
@@ -208,9 +204,6 @@ jobs:
             export NIMFLAGS="-d:nimRawSetjmp"
           fi
 
-          pwd
-          ls -al
-          ls build/lib/
           nim --version
           nimble --version
           nimble install -y --depsOnly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,4 @@ jobs:
           nimble --version
           nimble install -y --depsOnly
           nimble test
+          nimble test_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,15 @@ jobs:
         run: |
           /c/vcpkg/vcpkg --help
           export VCPKG_LIBRARY_LINKAGE=static
+          export VCPKG_BUILD_TYPE=release
           /c/vcpkg/vcpkg install rocksdb[core,lz4,zstd]
-          # mkdir build dir
-          # copy static deps
+
+          LIBS_DIR=build/lib/
+          mkdir -p ${LIBS_DIR}
+          cp /c/vcpkg/packages/lz4_x64-windows/lib/lz4.lib ${LIBS_DIR}
+          cp /c/vcpkg/packages/zstd_x64-windows/lib/zstd.lib ${LIBS_DIR}
+          cp /c/vcpkg/packages/rocksdb_x64-windows/lib/rocksdb.lib ${LIBS_DIR}
+
 
       - name: Path to cached dependencies (Windows)
         if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,13 @@ jobs:
           runner.os == 'Windows'
         run: |
           pwd
+          ls /c/
+          ls /d/
+          ls /d/a/
+          /c/vcpkg --help
           export VCPKG_LIBRARY_LINKAGE=static
-          echo $VCPKG_LIBRARY_LINKAGE
-          /vcpkg install rocksdb[core,lz4,zstd]
 
+          #/vcpkg install rocksdb[core,lz4,zstd]
           # mkdir build dir
           # copy static deps
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "vendor/rocksdb"]
+	path = vendor/rocksdb
+	url = https://github.com/facebook/rocksdb
+	ignore = dirty
+	branch = master

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To statically link librocksdb, you would do something like:
 nim c -d:rocksdb_static_linking --threads:on your_program.nim
 ```
 
-See the config.nims file which contains the static linking configuration which is switched on with the `rocksdb_static_linking` flag.
+See the config.nims file which contains the static linking configuration which is switched on with the `rocksdb_static_linking` flag. Note that static linking is currently not supported on windows.
 
 ### Contribution
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ See [simple_example](examples/simple_example.nim)
 To statically link librocksdb, you would do something like:
 
 ```nim
-nim c -d:LibrocksbStaticArgs='-l:librocksdb.a' --gcc.linkerexe=g++ --threads:on your_program.nim
+nim c -d:rocksdb_static_linking --threads:on your_program.nim
 ```
 
-(we need the C++ linker profile because it's a C++ library)
+See the config.nims file which contains the static linking configuration which is switched on with the `rocksdb_static_linking` flag.
 
 ### Contribution
 

--- a/config.nims
+++ b/config.nims
@@ -14,7 +14,7 @@ when fileExists("nimble.paths"):
 
 when defined(rocksdb_static_linking):
   #switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
-  switch("clang.linkerexe", "o64-clang++") # use the C++ linker profile because it's a C++ library
+  switch("clang.linkerexe", "clang++") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -19,6 +19,6 @@ when defined(rocksdb_static_linking):
   else:
     switch("gcc.linkerexe", "g++")
 
-  switch("dynlibOverride", "librocksdb")
-  switch("dynlibOverride", "liblz4")
-  switch("dynlibOverride", "libzstd")
+  switch("dynlibOverride", "rocksdb")
+  switch("dynlibOverride", "lz4")
+  switch("dynlibOverride", "zstd")

--- a/config.nims
+++ b/config.nims
@@ -11,3 +11,13 @@
 when fileExists("nimble.paths"):
   include "nimble.paths"
 # end Nimble config
+
+when defined(static_linking):
+  import std/os
+
+  const libsDir = currentSourcePath.parentDir() & "/vendor/rocksdb"
+  switch("dynlibOverrideAll")
+  switch("l", libsDir & "/librocksdb.a")
+  switch("l", libsDir & "/libz.a")
+  switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+  

--- a/config.nims
+++ b/config.nims
@@ -19,5 +19,12 @@ when defined(rocksdb_static_linking):
   switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "libz.a")
+  switch("dynlibOverride", "libbz2.a")
+  switch("dynlibOverride", "liblz4.a")
+  switch("dynlibOverride", "libzstd.a")
+
   switch("l", libsDir & "/librocksdb.a")
   switch("l", libsDir & "/libz.a")
+  switch("l", libsDir & "/libbz2.a")
+  switch("l", libsDir & "/liblz4.a")
+  switch("l", libsDir & "/libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -13,8 +13,12 @@ when fileExists("nimble.paths"):
 # end Nimble config
 
 when defined(rocksdb_static_linking):
-  #switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
-  switch("clang.linkerexe", "clang++") # use the C++ linker profile because it's a C++ library
+  # use the C++ linker profile because it's a C++ library
+  when defined(macosx):
+    switch("clang.linkerexe", "clang++")
+  else:
+    switch("gcc.linkerexe", "g++")
+
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -12,6 +12,8 @@ when fileExists("nimble.paths"):
   include "nimble.paths"
 # end Nimble config
 
+switch("gcc.exe", "gcc")
+
 when defined(rocksdb_static_linking):
   import std/[os, strutils]
 

--- a/config.nims
+++ b/config.nims
@@ -13,7 +13,8 @@ when fileExists("nimble.paths"):
 # end Nimble config
 
 when defined(rocksdb_static_linking):
-  switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+  #switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+  switch("clang.linkerexe", "o64-clang") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -12,17 +12,8 @@ when fileExists("nimble.paths"):
   include "nimble.paths"
 # end Nimble config
 
-switch("gcc.exe", "gcc")
-
 when defined(rocksdb_static_linking):
-  import std/[os, strutils]
-
-  const libsDir = currentSourcePath.parentDir().replace('\\', '/') & "/build/lib"
-
   switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")
-  switch("l", libsDir & "/librocksdb.a")
-  switch("l", libsDir & "/liblz4.a")
-  switch("l", libsDir & "/libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -19,6 +19,6 @@ when defined(rocksdb_static_linking):
   else:
     switch("gcc.linkerexe", "g++")
 
-  switch("dynlibOverride", "librocksdb.a")
-  switch("dynlibOverride", "liblz4.a")
-  switch("dynlibOverride", "libzstd.a")
+  switch("dynlibOverride", "librocksdb")
+  switch("dynlibOverride", "liblz4")
+  switch("dynlibOverride", "libzstd")

--- a/config.nims
+++ b/config.nims
@@ -14,7 +14,7 @@ when fileExists("nimble.paths"):
 
 when defined(rocksdb_static_linking):
   #switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
-  switch("clang.linkerexe", "o64-clang") # use the C++ linker profile because it's a C++ library
+  switch("clang.linkerexe", "o64-clang++") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")

--- a/config.nims
+++ b/config.nims
@@ -12,12 +12,12 @@ when fileExists("nimble.paths"):
   include "nimble.paths"
 # end Nimble config
 
-when defined(static_linking):
-  import std/os
+when defined(rocksdb_static_linking):
+  import std/[os, strutils]
 
-  const libsDir = currentSourcePath.parentDir() & "/vendor/rocksdb"
-  switch("dynlibOverrideAll")
+  const libsDir = currentSourcePath.parentDir().replace('\\', '/') & "/build/lib"
+  switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
+  switch("dynlibOverride", "librocksdb.a")
+  switch("dynlibOverride", "libz.a")
   switch("l", libsDir & "/librocksdb.a")
   switch("l", libsDir & "/libz.a")
-  switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
-  

--- a/config.nims
+++ b/config.nims
@@ -18,15 +18,11 @@ when defined(rocksdb_static_linking):
   import std/[os, strutils]
 
   const libsDir = currentSourcePath.parentDir().replace('\\', '/') & "/build/lib"
+
   switch("gcc.linkerexe", "g++") # use the C++ linker profile because it's a C++ library
   switch("dynlibOverride", "librocksdb.a")
-  switch("dynlibOverride", "libz.a")
-  switch("dynlibOverride", "libbz2.a")
   switch("dynlibOverride", "liblz4.a")
   switch("dynlibOverride", "libzstd.a")
-
   switch("l", libsDir & "/librocksdb.a")
-  switch("l", libsDir & "/libz.a")
-  switch("l", libsDir & "/libbz2.a")
   switch("l", libsDir & "/liblz4.a")
   switch("l", libsDir & "/libzstd.a")

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,3 @@
 --threads:on
 --outdir:build
+--hints:off

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,2 @@
--p:"src"
-
+--threads:on
+--outdir:build

--- a/rocksdb.nim
+++ b/rocksdb.nim
@@ -8,8 +8,13 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ./rocksdb/[backup, columnfamily, rocksdb, rocksiterator],
-  ./rocksdb/[sstfilewriter, transactiondb, writebatch]
+  ./rocksdb/[backup,
+  columnfamily,
+  rocksdb,
+  rocksiterator,
+  sstfilewriter,
+  transactiondb,
+  writebatch]
 
 export
   backup,

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -21,4 +21,5 @@ task test, "Run tests":
 
 task test_static, "Run tests after static linking dependencies":
   exec "scripts/build_static_deps.sh"
-  exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"
+  exec "cat vendor/rocksdb/make_config.mk"
+  #exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -20,5 +20,6 @@ task test, "Run tests":
   exec "nim c -r --threads:on tests/test_all.nim"
 
 task test_static, "Run tests after static linking dependencies":
-  exec "scripts/build_static_deps.sh"
+  when not defined(windows):
+    exec "scripts/build_static_deps.sh"
   exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -22,4 +22,4 @@ task test, "Run tests":
 task test_static, "Run tests after static linking dependencies":
   exec "scripts/build_static_deps.sh"
   exec "cat vendor/rocksdb/make_config.mk"
-  #exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"
+  exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -12,6 +12,10 @@ requires "nim >= 1.6",
          "tempfile",
          "unittest2"
 
+task clean, "Remove temporary files":
+  exec "rm -rf build"
+  exec "make -C vendor/rocksdb clean"
+
 task test, "Run tests":
   exec "nim c -r --threads:on tests/test_all.nim"
 

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -8,7 +8,7 @@ mode          = ScriptMode.Verbose
 
 ### Dependencies
 requires "nim >= 1.6",
-         "stew",
+         "results",
          "tempfile",
          "unittest2"
 
@@ -17,4 +17,4 @@ task test, "Run tests":
 
 task test_static, "Run tests after static linking dependencies":
   exec "scripts/build_static_deps.sh"
-  exec "nim c -d:static_linking -r --threads:on tests/test_all.nim"
+  exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -12,27 +12,9 @@ requires "nim >= 1.6",
          "tempfile",
          "unittest2"
 
-proc createBuildDir() =
-  if not dirExists "build":
-    mkDir "build"
-
-proc buildStaticDeps() =
-  exec "git submodule update --init"
-  exec "DEBUG_LEVEL=0 make -C vendor/rocksdb libz.a"
-  exec "DEBUG_LEVEL=0 make -C vendor/rocksdb static_lib"
-  # TODO: add this in later
-  #exec "strip --strip-unneeded vendor/rocksdb/libz.a vendor/rocksdb/librocksdb.a"
-
-task build_static, "Build static library":
-  createBuildDir()
-  buildStaticDeps()
-  exec "nim c -d:static_linking --app:staticlib rocksdb.nim"
-
 task test, "Run tests":
-  createBuildDir()
   exec "nim c -r --threads:on tests/test_all.nim"
 
 task test_static, "Run tests after static linking dependencies":
-  createBuildDir()
-  buildStaticDeps()
+  exec "scripts/build_static_deps.sh"
   exec "nim c -d:static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -21,5 +21,4 @@ task test, "Run tests":
 
 task test_static, "Run tests after static linking dependencies":
   exec "scripts/build_static_deps.sh"
-  exec "cat vendor/rocksdb/make_config.mk"
   exec "nim c -d:rocksdb_static_linking -r --threads:on tests/test_all.nim"

--- a/rocksdb/columnfamily/cfopts.nim
+++ b/rocksdb/columnfamily/cfopts.nim
@@ -36,7 +36,7 @@ proc defaultColFamilyOptions*(): ColFamilyOptionsRef =
   let opts = newColFamilyOptions()
 
   rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
-  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+  # rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
 
   # Enable creating column families if they do not exist
   opts.setCreateMissingColumnFamilies(true)

--- a/rocksdb/columnfamily/cfopts.nim
+++ b/rocksdb/columnfamily/cfopts.nim
@@ -34,6 +34,10 @@ proc setCreateMissingColumnFamilies*(cfOpts: ColFamilyOptionsRef, flag: bool) =
 
 proc defaultColFamilyOptions*(): ColFamilyOptionsRef =
   let opts = newColFamilyOptions()
+
+  rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
+  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+
   # Enable creating column families if they do not exist
   opts.setCreateMissingColumnFamilies(true)
   return opts

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -47,8 +47,6 @@ proc shouldUseNativeLinking(): bool {.compileTime.} =
   when defined(linux):
     return true
 
-const LibrocksbStaticArgs {.strdefine.}: string = ""
-
 type
   rocksdb_t* = object
   rocksdb_backup_engine_t* = object
@@ -114,9 +112,8 @@ type
 
 ##  DB operations
 
-when LibrocksbStaticArgs != "":
+when defined(static_linking):
   {.pragma: importrocks, importc, cdecl.}
-  {.passL: LibrocksbStaticArgs.}
   when defined(windows):
     {.passL: "-lshlwapi -lrpcrt4".}
 else:

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -113,15 +113,15 @@ type
 ##  DB operations
 
 when defined(rocksdb_static_linking):
-  import std/[os, strutils]
-
   {.pragma: importrocks, importc, cdecl.}
 
+  import std/[os, strutils]
   const
     topLevelPath = currentSourcePath.parentDir().parentDir().parentDir()
     libsDir = topLevelPath.replace('\\', '/') & "/build/lib"
 
   when defined(windows):
+    {.passL: "-lshlwapi -lrpcrt4".}
     {.passL: libsDir & "/rocksdb.lib".}
     {.passL: libsDir & "/lz4.lib".}
     {.passL: libsDir & "/zstd.lib".}
@@ -130,8 +130,6 @@ when defined(rocksdb_static_linking):
     {.passL: libsDir & "/liblz4.a".}
     {.passL: libsDir & "/libzstd.a".}
 
-  when defined(windows):
-    {.passL: "-lshlwapi -lrpcrt4".}
 else:
   when shouldUseNativeLinking():
     {.pragma: importrocks, importc, cdecl.}

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -121,9 +121,14 @@ when defined(rocksdb_static_linking):
     topLevelPath = currentSourcePath.parentDir().parentDir().parentDir()
     libsDir = topLevelPath.replace('\\', '/') & "/build/lib"
 
-  {.passL: libsDir & "/librocksdb.a".}
-  {.passL: libsDir & "/liblz4.a".}
-  {.passL: libsDir & "/libzstd.a".}
+  when defined(windows):
+    {.passL: libsDir & "/librocksdb.lib".}
+    {.passL: libsDir & "/liblz4.lib".}
+    {.passL: libsDir & "/libzstd.lib".}
+  else:
+    {.passL: libsDir & "/librocksdb.a".}
+    {.passL: libsDir & "/liblz4.a".}
+    {.passL: libsDir & "/libzstd.a".}
 
   when defined(windows):
     {.passL: "-lshlwapi -lrpcrt4".}

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -122,9 +122,9 @@ when defined(rocksdb_static_linking):
     libsDir = topLevelPath.replace('\\', '/') & "/build/lib"
 
   when defined(windows):
-    {.passL: libsDir & "/librocksdb.lib".}
-    {.passL: libsDir & "/liblz4.lib".}
-    {.passL: libsDir & "/libzstd.lib".}
+    {.passL: libsDir & "/rocksdb.lib".}
+    {.passL: libsDir & "/lz4.lib".}
+    {.passL: libsDir & "/zstd.lib".}
   else:
     {.passL: libsDir & "/librocksdb.a".}
     {.passL: libsDir & "/liblz4.a".}

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -112,7 +112,7 @@ type
 
 ##  DB operations
 
-when defined(static_linking):
+when defined(rocksdb_static_linking):
   {.pragma: importrocks, importc, cdecl.}
   when defined(windows):
     {.passL: "-lshlwapi -lrpcrt4".}

--- a/rocksdb/lib/librocksdb.nim
+++ b/rocksdb/lib/librocksdb.nim
@@ -113,7 +113,18 @@ type
 ##  DB operations
 
 when defined(rocksdb_static_linking):
+  import std/[os, strutils]
+
   {.pragma: importrocks, importc, cdecl.}
+
+  const
+    topLevelPath = currentSourcePath.parentDir().parentDir().parentDir()
+    libsDir = topLevelPath.replace('\\', '/') & "/build/lib"
+
+  {.passL: libsDir & "/librocksdb.a".}
+  {.passL: libsDir & "/liblz4.a".}
+  {.passL: libsDir & "/libzstd.a".}
+
   when defined(windows):
     {.passL: "-lshlwapi -lrpcrt4".}
 else:

--- a/rocksdb/options/backupopts.nim
+++ b/rocksdb/options/backupopts.nim
@@ -33,7 +33,7 @@ proc cPtr*(engineOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
 proc defaultBackupEngineOptions*(): BackupEngineOptionsRef {.inline.} =
   let opts = newBackupEngineOptions()
   rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
-  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+  # rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
   opts
 
 

--- a/rocksdb/options/backupopts.nim
+++ b/rocksdb/options/backupopts.nim
@@ -31,8 +31,11 @@ proc cPtr*(engineOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
 # TODO: Add setters and getters for backup options properties.
 
 proc defaultBackupEngineOptions*(): BackupEngineOptionsRef {.inline.} =
-  newBackupEngineOptions()
-  # TODO: set prefered defaults
+  let opts = newBackupEngineOptions()
+  rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
+  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+  opts
+
 
 proc close*(engineOpts: BackupEngineOptionsRef) =
   if not engineOpts.isClosed():

--- a/rocksdb/options/dbopts.nim
+++ b/rocksdb/options/dbopts.nim
@@ -51,7 +51,7 @@ proc defaultDbOptions*(): DbOptionsRef =
   let opts: DbOptionsRef = newDbOptions()
 
   rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
-  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+  # rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
 
   # Optimize RocksDB. This is the easiest way to get RocksDB to perform well:
   opts.setIncreaseParallelism(countProcessors())

--- a/rocksdb/options/dbopts.nim
+++ b/rocksdb/options/dbopts.nim
@@ -48,7 +48,11 @@ proc setCreateMissingColumnFamilies*(dbOpts: DbOptionsRef, flag: bool) =
   rocksdb_options_set_create_missing_column_families(dbOpts.cPtr, flag.uint8)
 
 proc defaultDbOptions*(): DbOptionsRef =
-  let opts = newDbOptions()
+  let opts: DbOptionsRef = newDbOptions()
+
+  rocksdb_options_set_compression(opts.cPtr, rocksdb_lz4_compression)
+  rocksdb_options_set_bottommost_compression(opts.cPtr, rocksdb_zstd_compression)
+
   # Optimize RocksDB. This is the easiest way to get RocksDB to perform well:
   opts.setIncreaseParallelism(countProcessors())
   # This requires snappy - disabled because rocksdb is not always compiled with

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -14,25 +14,40 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 REPO_DIR="${PWD}"
-ROCKSDB_LIB_DIR=$REPO_DIR/vendor/rocksdb
-BUILD_DEST=$REPO_DIR/build/lib
+ROCKSDB_LIB_DIR="${REPO_DIR}/vendor/rocksdb"
+BUILD_DEST="${REPO_DIR}/build/lib"
 
+[[ -z "$NPROC" ]] && NPROC=2 # number of CPU cores available
 
 git submodule update --init
-export EXTRA_CXXFLAGS=-fpermissive
-export DISABLE_WARNING_AS_ERROR=true
-DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a libbz2.a liblz4.a libzstd.a \
-    static_lib --no-print-directory # TODO: reduce output
+
+#export EXTRA_CXXFLAGS=-fpermissive # TODO: is this needed?
+export DISABLE_WARNING_AS_ERROR=1
+
+export ROCKSDB_DISABLE_SNAPPY=1
+export ROCKSDB_DISABLE_ZLIB=1
+export ROCKSDB_DISABLE_BZIP=1
+# export ROCKSDB_DISABLE_LZ4=1
+# export ROCKSDB_DISABLE_ZSTD=1
+
+export DEBUG_LEVEL=0
+
+make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory # TODO: reduce output
+
+export EXTRA_CFLAGS="-I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
+export EXTRA_CXXFLAGS="-I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
+
+make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} static_lib --no-print-directory # TODO: reduce output
 
 mkdir -p "${BUILD_DEST}"
 
-cp "${ROCKSDB_LIB_DIR}/libz.a" "${BUILD_DEST}/"
-cp "${ROCKSDB_LIB_DIR}/libbz2.a" "${BUILD_DEST}/"
+# cp "${ROCKSDB_LIB_DIR}/libz.a" "${BUILD_DEST}/"
+# cp "${ROCKSDB_LIB_DIR}/libbz2.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/liblz4.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/libzstd.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
 
-# TODO: fix this. --strip-unneeded is not supported on macos
+# TODO: Should we strip the static libraries?
 # strip --strip-unneeded "${BUILD_DEST}/libz.a"
 # strip --strip-unneeded "${BUILD_DEST}/libbz2.a"
 # strip --strip-unneeded "${BUILD_DEST}/liblz4.a"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -20,6 +20,7 @@ BUILD_DEST=$REPO_DIR/build/lib
 
 git submodule update --init
 export EXTRA_CXXFLAGS=-fpermissive
+export DISABLE_WARNING_AS_ERROR=true
 DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a libbz2.a liblz4.a libzstd.a \
     static_lib --no-print-directory # TODO: reduce output
 

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -12,15 +12,16 @@
 set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
+
 REPO_DIR="${PWD}"
 ROCKSDB_LIB_DIR=$REPO_DIR/vendor/rocksdb
 BUILD_DEST=$REPO_DIR/build/lib
 
+
 git submodule update --init
-DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a
-DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" static_lib
-# TODO: add this in later
-#exec "strip --strip-unneeded vendor/rocksdb/libz.a vendor/rocksdb/librocksdb.a"
+DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a static_lib --no-print-directory &>/dev/null
 
 mkdir -p "${BUILD_DEST}"
 cp "${ROCKSDB_LIB_DIR}/libz.a" "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
+
+strip --strip-unneeded "${BUILD_DEST}/libz.a" "${BUILD_DEST}/librocksdb.a"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -30,12 +30,13 @@ export ROCKSDB_DISABLE_BZIP=1
 # export ROCKSDB_DISABLE_LZ4=1
 # export ROCKSDB_DISABLE_ZSTD=1
 
+export PORTABLE=1
 export DEBUG_LEVEL=0
 
 make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory # TODO: reduce output
 
-export EXTRA_CFLAGS="-I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
-export EXTRA_CXXFLAGS="-I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
+export EXTRA_CFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
+export EXTRA_CXXFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
 
 make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} static_lib --no-print-directory # TODO: reduce output
 

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -19,9 +19,15 @@ BUILD_DEST=$REPO_DIR/build/lib
 
 
 git submodule update --init
-DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a static_lib --no-print-directory &>/dev/null
+DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a libbz2.a liblz4.a libzstd.a \
+    static_lib --no-print-directory # TODO: reduce output
 
 mkdir -p "${BUILD_DEST}"
-cp "${ROCKSDB_LIB_DIR}/libz.a" "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
+
+cp "${ROCKSDB_LIB_DIR}/libz.a" "${BUILD_DEST}/"
+cp "${ROCKSDB_LIB_DIR}/libbz2.a" "${BUILD_DEST}/"
+cp "${ROCKSDB_LIB_DIR}/liblz4.a" "${BUILD_DEST}/"
+cp "${ROCKSDB_LIB_DIR}/libzstd.a" "${BUILD_DEST}/"
+cp "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
 
 strip --strip-unneeded "${BUILD_DEST}/libz.a" "${BUILD_DEST}/librocksdb.a"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -32,6 +32,7 @@ export ROCKSDB_DISABLE_BZIP=1
 
 export PORTABLE=1
 export DEBUG_LEVEL=0
+export USE_CLANG=1
 
 make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory # TODO: reduce output
 

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -17,43 +17,32 @@ REPO_DIR="${PWD}"
 ROCKSDB_LIB_DIR="${REPO_DIR}/vendor/rocksdb"
 BUILD_DEST="${REPO_DIR}/build/lib"
 
+
+
 [[ -z "$NPROC" ]] && NPROC=2 # number of CPU cores available
 
 git submodule update --init
 
-#export EXTRA_CXXFLAGS=-fpermissive # TODO: is this needed?
 export DISABLE_WARNING_AS_ERROR=1
 
 export ROCKSDB_DISABLE_SNAPPY=1
 export ROCKSDB_DISABLE_ZLIB=1
 export ROCKSDB_DISABLE_BZIP=1
-# export ROCKSDB_DISABLE_LZ4=1
-# export ROCKSDB_DISABLE_ZSTD=1
 
 export PORTABLE=1
 export DEBUG_LEVEL=0
-# export USE_CLANG=1
 
-make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory # TODO: reduce output
+make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory > /dev/null
 
 export EXTRA_CFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
 export EXTRA_CXXFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
 
-make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} static_lib --no-print-directory # TODO: reduce output
+make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} static_lib --no-print-directory > /dev/null
 
-cat "${REPO_DIR}/vendor/rocksdb/make_config.mk"
+#cat "${REPO_DIR}/vendor/rocksdb/make_config.mk"
 
 mkdir -p "${BUILD_DEST}"
 
-# cp "${ROCKSDB_LIB_DIR}/libz.a" "${BUILD_DEST}/"
-# cp "${ROCKSDB_LIB_DIR}/libbz2.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/liblz4.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/libzstd.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
-
-# TODO: Should we strip the static libraries?
-# strip --strip-unneeded "${BUILD_DEST}/libz.a"
-# strip --strip-unneeded "${BUILD_DEST}/libbz2.a"
-# strip --strip-unneeded "${BUILD_DEST}/liblz4.a"
-# strip --strip-unneeded "${BUILD_DEST}/libzstd.a"
-# strip --strip-unneeded "${BUILD_DEST}/librocksdb.a"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Nim-RocksDB
+# Copyright 2018-2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
+REPO_DIR="${PWD}"
+ROCKSDB_LIB_DIR=$REPO_DIR/vendor/rocksdb
+BUILD_DEST=$REPO_DIR/build/lib
+
+git submodule update --init
+DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a
+DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" static_lib
+# TODO: add this in later
+#exec "strip --strip-unneeded vendor/rocksdb/libz.a vendor/rocksdb/librocksdb.a"
+
+mkdir -p "${BUILD_DEST}"
+cp "${ROCKSDB_LIB_DIR}/libz.a" "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -19,6 +19,7 @@ BUILD_DEST=$REPO_DIR/build/lib
 
 
 git submodule update --init
+export EXTRA_CXXFLAGS=-fpermissive
 DEBUG_LEVEL=0 make -C "${ROCKSDB_LIB_DIR}" libz.a libbz2.a liblz4.a libzstd.a \
     static_lib --no-print-directory # TODO: reduce output
 
@@ -30,4 +31,9 @@ cp "${ROCKSDB_LIB_DIR}/liblz4.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/libzstd.a" "${BUILD_DEST}/"
 cp "${ROCKSDB_LIB_DIR}/librocksdb.a" "${BUILD_DEST}/"
 
-strip --strip-unneeded "${BUILD_DEST}/libz.a" "${BUILD_DEST}/librocksdb.a"
+# TODO: fix this. --strip-unneeded is not supported on macos
+# strip --strip-unneeded "${BUILD_DEST}/libz.a"
+# strip --strip-unneeded "${BUILD_DEST}/libbz2.a"
+# strip --strip-unneeded "${BUILD_DEST}/liblz4.a"
+# strip --strip-unneeded "${BUILD_DEST}/libzstd.a"
+# strip --strip-unneeded "${BUILD_DEST}/librocksdb.a"

--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -32,7 +32,7 @@ export ROCKSDB_DISABLE_BZIP=1
 
 export PORTABLE=1
 export DEBUG_LEVEL=0
-export USE_CLANG=1
+# export USE_CLANG=1
 
 make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} liblz4.a libzstd.a --no-print-directory # TODO: reduce output
 
@@ -40,6 +40,8 @@ export EXTRA_CFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/l
 export EXTRA_CXXFLAGS="-fpermissive -Wno-error -w -I${ROCKSDB_LIB_DIR}/lz4-1.9.4/lib -I${ROCKSDB_LIB_DIR}/zstd-1.5.5/lib -DLZ4 -DZSTD"
 
 make -C "${ROCKSDB_LIB_DIR}" -j${NPROC} static_lib --no-print-directory # TODO: reduce output
+
+cat "${REPO_DIR}/vendor/rocksdb/make_config.mk"
 
 mkdir -p "${BUILD_DEST}"
 


### PR DESCRIPTION
This change adds support for static linking RocksDb on Linux and MacOS. Linking is currently unsupported on windows because RocksDb doesn't support building with Mingw which is what we use.

The library still supports being loaded dynamically as well so we test both scenarios in the CI.