### PR TITLE
Update API to support passing in ColFamilyHandleRef instead of column family string.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-latest
             shell: bash
           - target:
               os: macos
-            builder: macos-11
+            builder: macos-12
             shell: bash
           - target:
               os: windows

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -1,16 +1,14 @@
-packageName   = "rocksdb"
-version       = "0.4.0"
-author        = "Status Research & Development GmbH"
-description   = "A wrapper for Facebook's RocksDB, an embeddable, persistent key-value store for fast storage"
-license       = "Apache License 2.0 or GPLv2"
-skipDirs      = @["examples", "tests"]
-mode          = ScriptMode.Verbose
+packageName = "rocksdb"
+version = "0.5.0"
+author = "Status Research & Development GmbH"
+description =
+  "A wrapper for Facebook's RocksDB, an embeddable, persistent key-value store for fast storage"
+license = "Apache License 2.0 or GPLv2"
+skipDirs = @["examples", "tests"]
+mode = ScriptMode.Verbose
 
 ### Dependencies
-requires "nim >= 1.6",
-         "results",
-         "tempfile",
-         "unittest2"
+requires "nim >= 1.6", "results", "tempfile", "unittest2"
 
 task clean, "Remove temporary files":
   exec "rm -rf build"

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -102,7 +102,7 @@ proc openIterator*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite
 ): RocksDBResult[RocksIteratorRef] {.inline.} =
   ## Opens an `RocksIteratorRef` for the given column family.
-  cf.db.openIterator(cf.cfHandle)
+  cf.db.openIterator(cf.handle)
 
 proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef {.inline.} =
   ## Opens a `WriteBatchRef` for the given column family.

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -32,35 +32,23 @@ type
     db: RocksDbReadWriteRef
     cfHandle: ColFamilyHandleRef
 
-proc withColFamily*(
+proc getColFamily*(
     db: RocksDbReadOnlyRef, name: string
 ): RocksDBResult[ColFamilyReadOnly] =
   ## Creates a new `ColFamilyReadOnly` from the given `RocksDbReadOnlyRef` and
   ## column family name.
   doAssert not db.isClosed()
 
-  # validate that the column family exists
-  let cfHandle = ?db.getColFamilyHandle(name)
+  ok(ColFamilyReadOnly(db: db, cfHandle: ?db.getColFamilyHandle(name)))
 
-  discard db.keyExists(@[0.byte], cfHandle).valueOr:
-    return err(error)
-
-  ok(ColFamilyReadOnly(db: db, cfHandle: cfHandle))
-
-proc withColFamily*(
+proc getColFamily*(
     db: RocksDbReadWriteRef, name: string
 ): RocksDBResult[ColFamilyReadWrite] =
   ## Create a new `ColFamilyReadWrite` from the given `RocksDbReadWriteRef` and
   ## column family name.
   doAssert not db.isClosed()
 
-  # validate that the column family exists
-  let cfHandle = ?db.getColFamilyHandle(name)
-
-  discard db.keyExists(@[0.byte], cfHandle).valueOr:
-    return err(error)
-
-  ok(ColFamilyReadWrite(db: db, cfHandle: cfHandle))
+  ok(ColFamilyReadWrite(db: db, cfHandle: ?db.getColFamilyHandle(name)))
 
 proc db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto {.inline.} =
   ## Returns the underlying `RocksDbReadOnlyRef` or `RocksDbReadWriteRef`.

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -40,7 +40,7 @@ proc withColFamily*(
   doAssert not db.isClosed()
 
   # validate that the column family exists
-  let cfHandle = db.getColFamilyHandle(name)
+  let cfHandle = ?db.getColFamilyHandle(name)
 
   discard db.keyExists(@[0.byte], cfHandle).valueOr:
     return err(error)
@@ -55,7 +55,7 @@ proc withColFamily*(
   doAssert not db.isClosed()
 
   # validate that the column family exists
-  let cfHandle = db.getColFamilyHandle(name)
+  let cfHandle = ?db.getColFamilyHandle(name)
 
   discard db.keyExists(@[0.byte], cfHandle).valueOr:
     return err(error)

--- a/rocksdb/internal/cftable.nim
+++ b/rocksdb/internal/cftable.nim
@@ -9,23 +9,19 @@
 
 {.push raises: [].}
 
-import
-  std/tables,
-  ../columnfamily/cfhandle
+import std/tables, ../columnfamily/cfhandle
 
-export
-  cfhandle
+export cfhandle
 
-type
-  ColFamilyTableRef* = ref object
-    columnFamilies: TableRef[string, ColFamilyHandleRef]
+type ColFamilyTableRef* = ref object
+  columnFamilies: TableRef[string, ColFamilyHandleRef]
 
 proc newColFamilyTable*(
-    names: openArray[string],
-    handles: openArray[ColFamilyHandlePtr]): ColFamilyTableRef =
+    names: openArray[string], handles: openArray[ColFamilyHandlePtr]
+): ColFamilyTableRef =
   doAssert names.len() == handles.len()
 
-  let cfTable =  newTable[string, ColFamilyHandleRef]()
+  let cfTable = newTable[string, ColFamilyHandleRef]()
   for i, name in names:
     cfTable[name] = newColFamilyHandle(handles[i])
 
@@ -34,7 +30,7 @@ proc newColFamilyTable*(
 proc isClosed*(table: ColFamilyTableRef): bool {.inline.} =
   table.columnFamilies.isNil()
 
-proc get*(table: ColFamilyTableRef, name: string): ColFamilyHandleRef =
+proc get*(table: ColFamilyTableRef, name: string): ColFamilyHandleRef {.inline.} =
   table.columnFamilies.getOrDefault(name)
 
 proc close*(table: ColFamilyTableRef) =

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -211,8 +211,14 @@ proc openRocksDbReadOnly*(
     )
   ok(db)
 
-proc getColFamilyHandle*(db: RocksDbRef, name: string): ColFamilyHandleRef {.inline.} =
-  db.cfTable.get(name)
+proc getColFamilyHandle*(
+    db: RocksDbRef, name: string
+): RocksDBResult[ColFamilyHandleRef] =
+  let cfHandle = db.cfTable.get(name)
+  if cfHandle.isNil():
+    err("rocksdb: unknown column family")
+  else:
+    ok(cfHandle)
 
 proc isClosed*(db: RocksDbRef): bool {.inline.} =
   ## Returns `true` if the database has been closed and `false` otherwise.

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -35,14 +35,7 @@ import
   ./rocksresult,
   ./writebatch
 
-export
-  rocksresult,
-  dbopts,
-  readopts,
-  writeopts,
-  cfdescriptor,
-  rocksiterator,
-  writebatch
+export rocksresult, dbopts, readopts, writeopts, cfdescriptor, rocksiterator, writebatch
 
 type
   RocksDbPtr* = ptr rocksdb_t
@@ -54,7 +47,7 @@ type
     path: string
     dbOpts: DbOptionsRef
     readOpts: ReadOptionsRef
-    defaultCfName: string
+    defaultCfHandle: ColFamilyHandleRef
     cfTable: ColFamilyTableRef
 
   RocksDbReadOnlyRef* = ref object of RocksDbRef
@@ -64,9 +57,8 @@ type
     ingestOptsPtr: IngestExternalFilesOptionsPtr
 
 proc listColumnFamilies*(
-    path: string;
-    dbOpts = DbOptionsRef(nil);
-      ): RocksDBResult[seq[string]] =
+    path: string, dbOpts = DbOptionsRef(nil)
+): RocksDBResult[seq[string]] =
   ## List exisiting column families on disk. This might be used to find out
   ## whether there were some columns missing with the version on disk.
   ##
@@ -78,30 +70,28 @@ proc listColumnFamilies*(
   ## above once rocksdb has been upgraded to the latest version, see comments
   ## at the end of ./columnfamily/cfhandle.nim.
   ##
-  let
-    useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
+  let useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
   defer:
-    if dbOpts.isNil: useDbOpts.close()
+    if dbOpts.isNil:
+      useDbOpts.close()
 
   var
     lencf: csize_t
     errors: cstring
-  let
-    cList = rocksdb_list_column_families(
-    useDbOpts.cPtr,
-    path.cstring,
-    addr lencf,
-    cast[cstringArray](errors.addr))
+  let cList = rocksdb_list_column_families(
+    useDbOpts.cPtr, path.cstring, addr lencf, cast[cstringArray](errors.addr)
+  )
   bailOnErrors(errors)
 
   var cfs: seq[string]
   if not cList.isNil:
-    defer: rocksdb_free(cList)
+    defer:
+      rocksdb_free(cList)
 
     for n in 0 ..< lencf:
       if cList[n].isNil:
         # Clean up the rest
-        for z in n+1 ..< lencf:
+        for z in n + 1 ..< lencf:
           if not cList[z].isNil:
             rocksdb_free(cList[z])
         return err("short reply")
@@ -112,22 +102,22 @@ proc listColumnFamilies*(
   ok cfs
 
 proc openRocksDb*(
-    path: string;
-    dbOpts = DbOptionsRef(nil);
-    readOpts = ReadOptionsRef(nil);
-    writeOpts = WriteOptionsRef(nil);
-    columnFamilies: openArray[ColFamilyDescriptor] = [];
-      ): RocksDBResult[RocksDbReadWriteRef] =
+    path: string,
+    dbOpts = DbOptionsRef(nil),
+    readOpts = ReadOptionsRef(nil),
+    writeOpts = WriteOptionsRef(nil),
+    columnFamilies: openArray[ColFamilyDescriptor] = [],
+): RocksDBResult[RocksDbReadWriteRef] =
   ## Open a RocksDB instance in read-write mode. If `columnFamilies` is empty
   ## then it will open the default column family. If `dbOpts`, `readOpts`, or
   ## `writeOpts` are not supplied then the default options will be used.
   ## By default, column families will be created if they don't yet exist.
   ## All existing column families must be specified if the database has
   ## previously created any column families.
-  let
-    useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
+  let useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
   defer:
-    if dbOpts.isNil: useDbOpts.close()
+    if dbOpts.isNil:
+      useDbOpts.close()
 
   var cfs = columnFamilies.toSeq()
   if DEFAULT_COLUMN_FAMILY_NAME notin columnFamilies.mapIt(it.name()):
@@ -139,19 +129,21 @@ proc openRocksDb*(
     cfHandles = newSeq[ColFamilyHandlePtr](cfs.len)
     errors: cstring
   let rocksDbPtr = rocksdb_open_column_families(
-        useDbOpts.cPtr,
-        path.cstring,
-        cfNames.len().cint,
-        cast[cstringArray](cfNames[0].addr),
-        cfOpts[0].addr,
-        cfHandles[0].addr,
-        cast[cstringArray](errors.addr))
+    useDbOpts.cPtr,
+    path.cstring,
+    cfNames.len().cint,
+    cast[cstringArray](cfNames[0].addr),
+    cfOpts[0].addr,
+    cfHandles[0].addr,
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   let
     dbOpts = useDbOpts # don't close on exit
     readOpts = (if readOpts.isNil: defaultReadOptions() else: readOpts)
     writeOpts = (if writeOpts.isNil: defaultWriteOptions() else: writeOpts)
+    cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)
     db = RocksDbReadWriteRef(
       lock: createLock(),
       cPtr: rocksDbPtr,
@@ -160,27 +152,28 @@ proc openRocksDb*(
       readOpts: readOpts,
       writeOpts: writeOpts,
       ingestOptsPtr: rocksdb_ingestexternalfileoptions_create(),
-      defaultCfName: DEFAULT_COLUMN_FAMILY_NAME,
-      cfTable: newColFamilyTable(cfNames.mapIt($it), cfHandles))
+      defaultCfHandle: cfTable.get(DEFAULT_COLUMN_FAMILY_NAME),
+      cfTable: cfTable,
+    )
   ok(db)
 
 proc openRocksDbReadOnly*(
-    path: string;
-    dbOpts = DbOptionsRef(nil);
-    readOpts = ReadOptionsRef(nil);
-    columnFamilies: openArray[ColFamilyDescriptor] = [];
-    errorIfWalFileExists = false;
-      ): RocksDBResult[RocksDbReadOnlyRef] =
+    path: string,
+    dbOpts = DbOptionsRef(nil),
+    readOpts = ReadOptionsRef(nil),
+    columnFamilies: openArray[ColFamilyDescriptor] = [],
+    errorIfWalFileExists = false,
+): RocksDBResult[RocksDbReadOnlyRef] =
   ## Open a RocksDB instance in read-only mode. If `columnFamilies` is empty
   ## then it will open the default column family. If `dbOpts` or `readOpts` are
   ## not supplied then the default options will be used. By default, column
   ## families will be created if they don't yet exist. If the database already
   ## contains any column families, then all or a subset of the existing column
   ## families can be opened for reading.
-  let
-    useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
+  let useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
   defer:
-    if dbOpts.isNil: useDbOpts.close()
+    if dbOpts.isNil:
+      useDbOpts.close()
 
   var cfs = columnFamilies.toSeq()
   if DEFAULT_COLUMN_FAMILY_NAME notin columnFamilies.mapIt(it.name()):
@@ -192,28 +185,34 @@ proc openRocksDbReadOnly*(
     cfHandles = newSeq[ColFamilyHandlePtr](cfs.len)
     errors: cstring
   let rocksDbPtr = rocksdb_open_for_read_only_column_families(
-        useDbOpts.cPtr,
-        path.cstring,
-        cfNames.len().cint,
-        cast[cstringArray](cfNames[0].addr),
-        cfOpts[0].addr,
-        cfHandles[0].addr,
-        errorIfWalFileExists.uint8,
-        cast[cstringArray](errors.addr))
+    useDbOpts.cPtr,
+    path.cstring,
+    cfNames.len().cint,
+    cast[cstringArray](cfNames[0].addr),
+    cfOpts[0].addr,
+    cfHandles[0].addr,
+    errorIfWalFileExists.uint8,
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   let
     dbOpts = useDbOpts # don't close on exit
     readOpts = (if readOpts.isNil: defaultReadOptions() else: readOpts)
+    cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)
     db = RocksDbReadOnlyRef(
       lock: createLock(),
       cPtr: rocksDbPtr,
       path: path,
       dbOpts: dbOpts,
       readOpts: readOpts,
-      defaultCfName: DEFAULT_COLUMN_FAMILY_NAME,
-      cfTable: newColFamilyTable(cfNames.mapIt($it), cfHandles))
+      defaultCfHandle: cfTable.get(DEFAULT_COLUMN_FAMILY_NAME),
+      cfTable: cfTable,
+    )
   ok(db)
+
+proc getColFamilyHandle*(db: RocksDbRef, name: string): ColFamilyHandleRef {.inline.} =
+  db.cfTable.get(name)
 
 proc isClosed*(db: RocksDbRef): bool {.inline.} =
   ## Returns `true` if the database has been closed and `false` otherwise.
@@ -228,7 +227,8 @@ proc get*(
     db: RocksDbRef,
     key: openArray[byte],
     onData: DataProc,
-    columnFamily = db.defaultCfName): RocksDBResult[bool] =
+    cfHandle = db.defaultCfHandle,
+): RocksDBResult[bool] =
   ## Get the value for the given key from the specified column family.
   ## If the value does not exist, `false` will be returned in the result
   ## and `onData` will not be called. If the value does exist, `true` will be
@@ -239,21 +239,18 @@ proc get*(
   if key.len() == 0:
     return err("rocksdb: key is empty")
 
-  let cfHandle = db.cfTable.get(columnFamily)
-  if cfHandle.isNil():
-    return err("rocksdb: unknown column family")
-
   var
     len: csize_t
     errors: cstring
   let data = rocksdb_get_cf(
-        db.cPtr,
-        db.readOpts.cPtr,
-        cfHandle.cPtr,
-        cast[cstring](unsafeAddr key[0]),
-        csize_t(key.len),
-        len.addr,
-        cast[cstringArray](errors.addr))
+    db.cPtr,
+    db.readOpts.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](unsafeAddr key[0]),
+    csize_t(key.len),
+    len.addr,
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   if data.isNil():
@@ -265,53 +262,52 @@ proc get*(
     ok(true)
 
 proc get*(
-    db: RocksDbRef,
-    key: openArray[byte],
-    columnFamily = db.defaultCfName): RocksDBResult[seq[byte]] =
+    db: RocksDbRef, key: openArray[byte], cfHandle = db.defaultCfHandle
+): RocksDBResult[seq[byte]] =
   ## Get the value for the given key from the specified column family.
   ## If the value does not exist, an empty error will be returned in the result.
   ## If the value does exist, the value will be returned in the result.
 
   var dataRes: RocksDBResult[seq[byte]]
-  proc onData(data: openArray[byte]) = dataRes.ok(@data)
+  proc onData(data: openArray[byte]) =
+    dataRes.ok(@data)
 
-  let res = db.get(key, onData, columnFamily)
+  let res = db.get(key, onData, cfHandle)
   if res.isOk():
     return dataRes
 
   dataRes.err(res.error())
 
 proc put*(
-    db: RocksDbReadWriteRef,
-    key, val: openArray[byte],
-    columnFamily = db.defaultCfName): RocksDBResult[void] =
+    db: RocksDbReadWriteRef, key, val: openArray[byte], cfHandle = db.defaultCfHandle
+): RocksDBResult[void] =
   ## Put the value for the given key into the specified column family.
 
   if key.len() == 0:
     return err("rocksdb: key is empty")
 
-  let cfHandle = db.cfTable.get(columnFamily)
-  if cfHandle.isNil():
-    return err("rocksdb: unknown column family")
-
   var errors: cstring
   rocksdb_put_cf(
-      db.cPtr,
-      db.writeOpts.cPtr,
-      cfHandle.cPtr,
-      cast[cstring](unsafeAddr key[0]),
-      csize_t(key.len),
-      cast[cstring](if val.len > 0: unsafeAddr val[0] else: nil),
-      csize_t(val.len),
-      cast[cstringArray](errors.addr))
+    db.cPtr,
+    db.writeOpts.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](unsafeAddr key[0]),
+    csize_t(key.len),
+    cast[cstring](if val.len > 0:
+      unsafeAddr val[0]
+    else:
+      nil
+    ),
+    csize_t(val.len),
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   ok()
 
 proc keyExists*(
-    db: RocksDbRef,
-    key: openArray[byte],
-    columnFamily = db.defaultCfName): RocksDBResult[bool] =
+    db: RocksDbRef, key: openArray[byte], cfHandle = db.defaultCfHandle
+): RocksDBResult[bool] =
   ## Check if the key exists in the specified column family.
   ## Returns a result containing `true` if the key exists or a result
   ## containing `false` otherwise.
@@ -319,12 +315,17 @@ proc keyExists*(
   # TODO: Call rocksdb_key_may_exist_cf to improve performance for the case
   # when the key does not exist
 
-  db.get(key, proc(data: openArray[byte]) = discard, columnFamily)
+  db.get(
+    key,
+    proc(data: openArray[byte]) =
+      discard
+    ,
+    cfHandle,
+  )
 
 proc delete*(
-    db: RocksDbReadWriteRef,
-    key: openArray[byte],
-    columnFamily = db.defaultCfName): RocksDBResult[void] =
+    db: RocksDbReadWriteRef, key: openArray[byte], cfHandle = db.defaultCfHandle
+): RocksDBResult[void] =
   ## Delete the value for the given key from the specified column family.
   ## If the value does not exist, the delete will be a no-op.
   ## To check if the value exists before or after a delete, use `keyExists`.
@@ -332,75 +333,57 @@ proc delete*(
   if key.len() == 0:
     return err("rocksdb: key is empty")
 
-  let cfHandle = db.cfTable.get(columnFamily)
-  if cfHandle.isNil:
-    return err("rocksdb: unknown column family")
-
   var errors: cstring
   rocksdb_delete_cf(
-      db.cPtr,
-      db.writeOpts.cPtr,
-      cfHandle.cPtr,
-      cast[cstring](unsafeAddr key[0]),
-      csize_t(key.len),
-      cast[cstringArray](errors.addr))
+    db.cPtr,
+    db.writeOpts.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](unsafeAddr key[0]),
+    csize_t(key.len),
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   ok()
 
 proc openIterator*(
-    db: RocksDbRef,
-    columnFamily = db.defaultCfName): RocksDBResult[RocksIteratorRef] =
+    db: RocksDbRef, cfHandle = db.defaultCfHandle
+): RocksDBResult[RocksIteratorRef] =
   ## Opens an `RocksIteratorRef` for the specified column family.
   doAssert not db.isClosed()
 
-  let cfHandle  = db.cfTable.get(columnFamily)
-  if cfHandle.isNil():
-    return err("rocksdb: unknown column family")
-
-  let rocksIterPtr = rocksdb_create_iterator_cf(
-        db.cPtr,
-        db.readOpts.cPtr,
-        cfHandle.cPtr)
+  let rocksIterPtr =
+    rocksdb_create_iterator_cf(db.cPtr, db.readOpts.cPtr, cfHandle.cPtr)
 
   ok(newRocksIterator(rocksIterPtr))
 
 proc openWriteBatch*(
-    db: RocksDbReadWriteRef,
-    columnFamily = db.defaultCfName): WriteBatchRef =
+    db: RocksDbReadWriteRef, cfHandle = db.defaultCfHandle
+): WriteBatchRef =
   ## Opens a `WriteBatchRef` which defaults to using the specified column family.
   doAssert not db.isClosed()
 
-  newWriteBatch(db.cfTable, columnFamily)
+  newWriteBatch(cfHandle)
 
-proc write*(
-    db: RocksDbReadWriteRef,
-    updates: WriteBatchRef): RocksDBResult[void] =
+proc write*(db: RocksDbReadWriteRef, updates: WriteBatchRef): RocksDBResult[void] =
   ## Apply the updates in the `WriteBatchRef` to the database.
   doAssert not db.isClosed()
 
   var errors: cstring
   rocksdb_write(
-      db.cPtr,
-      db.writeOpts.cPtr,
-      updates.cPtr,
-      cast[cstringArray](errors.addr))
+    db.cPtr, db.writeOpts.cPtr, updates.cPtr, cast[cstringArray](errors.addr)
+  )
   bailOnErrors(errors)
 
   ok()
 
 proc ingestExternalFile*(
-    db: RocksDbReadWriteRef,
-    filePath: string,
-    columnFamily = db.defaultCfName): RocksDBResult[void] =
+    db: RocksDbReadWriteRef, filePath: string, cfHandle = db.defaultCfHandle
+): RocksDBResult[void] =
   ## Ingest an external sst file into the database. The file will be ingested
   ## into the specified column family or the default column family if none is
   ## provided.
   doAssert not db.isClosed()
-
-  let cfHandle  = db.cfTable.get(columnFamily)
-  if cfHandle.isNil():
-    return err("rocksdb: unknown column family")
 
   var
     sstPath = filePath.cstring
@@ -408,9 +391,11 @@ proc ingestExternalFile*(
   rocksdb_ingest_external_file_cf(
     db.cPtr,
     cfHandle.cPtr,
-    cast[cstringArray](sstPath.addr), csize_t(1),
+    cast[cstringArray](sstPath.addr),
+    csize_t(1),
     db.ingestOptsPtr,
-    cast[cstringArray](errors.addr))
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   ok()

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -94,8 +94,12 @@ proc openTransactionDb*(
 
 proc getColFamilyHandle*(
     db: TransactionDbRef, name: string
-): ColFamilyHandleRef {.inline.} =
-  db.cfTable.get(name)
+): RocksDBResult[ColFamilyHandleRef] =
+  let cfHandle = db.cfTable.get(name)
+  if cfHandle.isNil():
+    err("rocksdb: unknown column family")
+  else:
+    ok(cfHandle)
 
 proc isClosed*(db: TransactionDbRef): bool {.inline.} =
   ## Returns `true` if the `TransactionDbRef` has been closed.

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -25,14 +25,7 @@ import
   ./rocksresult
 
 export
-  dbopts,
-  txdbopts,
-  cfdescriptor,
-  readopts,
-  writeopts,
-  txopts,
-  transaction,
-  rocksresult
+  dbopts, txdbopts, cfdescriptor, readopts, writeopts, txopts, transaction, rocksresult
 
 type
   TransactionDbPtr* = ptr rocksdb_transactiondb_t
@@ -43,21 +36,22 @@ type
     path: string
     dbOpts: DbOptionsRef
     txDbOpts: TransactionDbOptionsRef
+    defaultCfHandle: ColFamilyHandleRef
     cfTable: ColFamilyTableRef
 
 proc openTransactionDb*(
     path: string,
-    dbOpts = DbOptionsRef(nil);
-    txDbOpts = TransactionDbOptionsRef(nil);
-    columnFamilies: openArray[ColFamilyDescriptor] = [];
-      ): RocksDBResult[TransactionDbRef] =
+    dbOpts = DbOptionsRef(nil),
+    txDbOpts = TransactionDbOptionsRef(nil),
+    columnFamilies: openArray[ColFamilyDescriptor] = [],
+): RocksDBResult[TransactionDbRef] =
   ## Open a `TransactionDbRef` with the given options and column families.
   ## If no column families are provided the default column family will be used.
   ## If no options are provided the default options will be used.
-  let
-    useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
+  let useDbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
   defer:
-    if dbOpts.isNil: useDbOpts.close()
+    if dbOpts.isNil:
+      useDbOpts.close()
 
   var cfs = columnFamilies.toSeq()
   if DEFAULT_COLUMN_FAMILY_NAME notin columnFamilies.mapIt(it.name()):
@@ -70,56 +64,65 @@ proc openTransactionDb*(
     errors: cstring
 
   let txDbPtr = rocksdb_transactiondb_open_column_families(
-        useDbOpts.cPtr,
-        txDbOpts.cPtr,
-        path.cstring,
-        cfNames.len().cint,
-        cast[cstringArray](cfNames[0].addr),
-        cfOpts[0].addr,
-        cfHandles[0].addr,
-        cast[cstringArray](errors.addr))
+    useDbOpts.cPtr,
+    txDbOpts.cPtr,
+    path.cstring,
+    cfNames.len().cint,
+    cast[cstringArray](cfNames[0].addr),
+    cfOpts[0].addr,
+    cfHandles[0].addr,
+    cast[cstringArray](errors.addr),
+  )
   bailOnErrors(errors)
 
   let
     dbOpts = useDbOpts # don't close on exit
-    txDbOpts = (if txDbOpts.isNil: defaultTransactionDbOptions() else: txDbOpts)
+    txDbOpts = (if txDbOpts.isNil: defaultTransactionDbOptions()
+    else: txDbOpts
+    )
+    cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)
     db = TransactionDbRef(
       lock: createLock(),
       cPtr: txDbPtr,
       path: path,
       dbOpts: dbOpts,
       txDbOpts: txDbOpts,
-      cfTable: newColFamilyTable(cfNames.mapIt($it), cfHandles))
+      defaultCfHandle: cfTable.get(DEFAULT_COLUMN_FAMILY_NAME),
+      cfTable: cfTable,
+    )
   ok(db)
+
+proc getColFamilyHandle*(
+    db: TransactionDbRef, name: string
+): ColFamilyHandleRef {.inline.} =
+  db.cfTable.get(name)
 
 proc isClosed*(db: TransactionDbRef): bool {.inline.} =
   ## Returns `true` if the `TransactionDbRef` has been closed.
   db.cPtr.isNil()
 
 proc beginTransaction*(
-    db: TransactionDbRef;
-    readOpts = ReadOptionsRef(nil);
-    writeOpts = WriteOptionsRef(nil);
-    txDbOpts = TransactionDbOptionsRef(nil);
-    txOpts = defaultTransactionOptions();
-    columnFamily = DEFAULT_COLUMN_FAMILY_NAME;
-      ): TransactionRef =
+    db: TransactionDbRef,
+    readOpts = ReadOptionsRef(nil),
+    writeOpts = WriteOptionsRef(nil),
+    txDbOpts = TransactionDbOptionsRef(nil),
+    txOpts = defaultTransactionOptions(),
+    cfHandle = db.defaultCfHandle,
+): TransactionRef =
   ## Begin a new transaction against the database. The transaction will default
   ## to using the specified column family. If no column family is specified
   ## then the default column family will be used.
   doAssert not db.isClosed()
   let
-    txDbOpts = (if txDbOpts.isNil: defaultTransactionDbOptions() else: txDbOpts)
+    txDbOpts = (if txDbOpts.isNil: defaultTransactionDbOptions()
+    else: txDbOpts
+    )
     readOpts = (if readOpts.isNil: defaultReadOptions() else: readOpts)
     writeOpts = (if writeOpts.isNil: defaultWriteOptions() else: writeOpts)
 
-  let txPtr = rocksdb_transaction_begin(
-        db.cPtr,
-        writeOpts.cPtr,
-        txOpts.cPtr,
-        nil)
+  let txPtr = rocksdb_transaction_begin(db.cPtr, writeOpts.cPtr, txOpts.cPtr, nil)
 
-  newTransaction(txPtr, readOpts, writeOpts, txOpts, columnFamily, db.cfTable)
+  newTransaction(txPtr, readOpts, writeOpts, txOpts, cfHandle)
 
 proc close*(db: TransactionDbRef) =
   ## Close the `TransactionDbRef`.

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -9,12 +9,7 @@
 
 {.used.}
 
-import
-  std/os,
-  tempfile,
-  unittest2,
-  ../rocksdb/columnfamily,
-  ./test_helper
+import std/os, tempfile, unittest2, ../rocksdb/columnfamily, ./test_helper
 
 suite "ColFamily Tests":
   const
@@ -43,8 +38,18 @@ suite "ColFamily Tests":
     check cf.put(key, val).isOk()
 
     var bytes: seq[byte]
-    check cf.get(key, proc(data: openArray[byte]) = bytes = @data)[]
-    check not cf.get(otherKey, proc(data: openArray[byte]) = bytes = @data)[]
+    check cf.get(
+      key,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+    )[]
+    check not cf.get(
+      otherKey,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+    )[]
 
     var r1 = cf.get(key)
     check r1.isOk() and r1.value == val

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -31,7 +31,7 @@ suite "ColFamily Tests":
     removeDir($dbPath)
 
   test "Basic operations":
-    let r0 = db.withColFamily(CF_OTHER)
+    let r0 = db.getColFamily(CF_OTHER)
     check r0.isOk()
     let cf = r0.value()
 
@@ -78,7 +78,7 @@ suite "ColFamily Tests":
 
     # Open database in read only mode
     block:
-      var res = initReadOnlyDb(dbPath).withColFamily(CF_DEFAULT)
+      var res = initReadOnlyDb(dbPath).getColFamily(CF_DEFAULT)
       check res.isOk()
 
       let readOnlyCf = res.value()

--- a/tests/test_helper.nim
+++ b/tests/test_helper.nim
@@ -9,50 +9,43 @@
 
 {.used.}
 
-import
-    std/sequtils,
-  ../rocksdb/backup,
-  ../rocksdb/rocksdb,
-  ../rocksdb/transactiondb
-
+import std/sequtils, ../rocksdb/backup, ../rocksdb/rocksdb, ../rocksdb/transactiondb
 
 proc initReadWriteDb*(
-    path: string,
-    columnFamilyNames: openArray[string] = @[]): RocksDbReadWriteRef =
-
+    path: string, columnFamilyNames: openArray[string] = @[]
+): RocksDbReadWriteRef =
   let res = openRocksDb(
-      path,
-      columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)))
+    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
+  )
   if res.isErr():
     echo res.error()
   doAssert res.isOk()
   res.value()
 
 proc initReadOnlyDb*(
-    path: string,
-    columnFamilyNames: openArray[string] = @[]): RocksDbReadOnlyRef =
-
+    path: string, columnFamilyNames: openArray[string] = @[]
+): RocksDbReadOnlyRef =
   let res = openRocksDbReadOnly(
-      path,
-      columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)))
+    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
+  )
   if res.isErr():
     echo res.error()
   doAssert res.isOk()
   res.value()
 
 proc initBackupEngine*(path: string): BackupEngineRef =
-
   let res = openBackupEngine(path)
   doAssert res.isOk()
   res.value()
 
 proc initTransactionDb*(
-    path: string,
-    columnFamilyNames: openArray[string] = @[]): TransactionDbRef =
-
+    path: string, columnFamilyNames: openArray[string] = @[]
+): TransactionDbRef =
   let res = openTransactionDb(
-      path,
-      columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)))
+    path,
+    txDbOpts = defaultTransactionDbOptions(),
+    columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)),
+  )
   if res.isErr():
     echo res.error()
   doAssert res.isOk()

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -9,12 +9,7 @@
 
 {.used.}
 
-import
-  std/os,
-  tempfile,
-  unittest2,
-  ../rocksdb/rocksdb,
-  ./test_helper
+import std/os, tempfile, unittest2, ../rocksdb/rocksdb, ./test_helper
 
 suite "RocksDbRef Tests":
   const
@@ -30,19 +25,30 @@ suite "RocksDbRef Tests":
     let
       dbPath = mkdtemp() / "data"
       db = initReadWriteDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+      defaultCfHandle = db.getColFamilyHandle(CF_DEFAULT).get()
+      otherCfHandle = db.getColFamilyHandle(CF_OTHER).get()
 
   teardown:
     db.close()
     removeDir($dbPath)
 
   test "Basic operations":
-
     var s = db.put(key, val)
     check s.isOk()
 
     var bytes: seq[byte]
-    check db.get(key, proc(data: openArray[byte]) = bytes = @data)[]
-    check not db.get(otherKey, proc(data: openArray[byte]) = bytes = @data)[]
+    check db.get(
+      key,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+    )[]
+    check not db.get(
+      otherKey,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+    )[]
 
     var r1 = db.get(key)
     check r1.isOk() and r1.value == val
@@ -84,13 +90,24 @@ suite "RocksDbRef Tests":
       check readOnlyDb.isClosed()
 
   test "Basic operations - default column family":
-
-    var s = db.put(key, val, CF_DEFAULT)
+    var s = db.put(key, val, defaultCfHandle)
     check s.isOk()
 
     var bytes: seq[byte]
-    check db.get(key, proc(data: openArray[byte]) = bytes = @data, CF_DEFAULT)[]
-    check not db.get(otherKey, proc(data: openArray[byte]) = bytes = @data, CF_DEFAULT)[]
+    check db.get(
+      key,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+      defaultCfHandle,
+    )[]
+    check not db.get(
+      otherKey,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+      defaultCfHandle,
+    )[]
 
     var r1 = db.get(key)
     check r1.isOk() and r1.value == val
@@ -99,79 +116,20 @@ suite "RocksDbRef Tests":
     # there's no error string for missing keys
     check r2.isOk() == false and r2.error.len == 0
 
-    var e1 = db.keyExists(key, CF_DEFAULT)
+    var e1 = db.keyExists(key, defaultCfHandle)
     check e1.isOk() and e1.value == true
 
-    var e2 = db.keyExists(otherKey, CF_DEFAULT)
+    var e2 = db.keyExists(otherKey, defaultCfHandle)
     check e2.isOk() and e2.value == false
 
-    var d = db.delete(key, CF_DEFAULT)
+    var d = db.delete(key, defaultCfHandle)
     check d.isOk()
 
-    e1 = db.keyExists(key, CF_DEFAULT)
+    e1 = db.keyExists(key, defaultCfHandle)
     check e1.isOk() and e1.value == false
 
-    d = db.delete(otherKey, CF_DEFAULT)
+    d = db.delete(otherKey, defaultCfHandle)
     check d.isOk()
-
-    close(db)
-    check db.isClosed()
-
-    # Open database in read only mode
-    block:
-      var
-        readOnlyDb = initReadOnlyDb(dbPath, columnFamilyNames = @[CF_DEFAULT])
-        r = readOnlyDb.keyExists(key, CF_DEFAULT)
-      check r.isOk() and r.value == false
-
-      # Won't compile as designed:
-      # var r2 = readOnlyDb.put(key, @[123.byte], CF_DEFAULT)
-      # check r2.isErr()
-
-      readOnlyDb.close()
-      check readOnlyDb.isClosed()
-
-  test "Basic operations - multiple column families":
-
-    var s = db.put(key, val, CF_DEFAULT)
-    check s.isOk()
-
-    var s2 = db.put(otherKey, val, CF_OTHER)
-    check s2.isOk()
-
-    var bytes: seq[byte]
-    check db.get(key, proc(data: openArray[byte]) = bytes = @data, CF_DEFAULT)[]
-    check not db.get(otherKey, proc(data: openArray[byte]) = bytes = @data, CF_DEFAULT)[]
-
-    var bytes2: seq[byte]
-    check db.get(otherKey, proc(data: openArray[byte]) = bytes2 = @data, CF_OTHER)[]
-    check not db.get(key, proc(data: openArray[byte]) = bytes2 = @data, CF_OTHER)[]
-
-    var e1 = db.keyExists(key, CF_DEFAULT)
-    check e1.isOk() and e1.value == true
-    var e2 = db.keyExists(otherKey, CF_DEFAULT)
-    check e2.isOk() and e2.value == false
-
-    var e3 = db.keyExists(key, CF_OTHER)
-    check e3.isOk() and e3.value == false
-    var e4 = db.keyExists(otherKey, CF_OTHER)
-    check e4.isOk() and e4.value == true
-
-    var d = db.delete(key, CF_DEFAULT)
-    check d.isOk()
-    e1 = db.keyExists(key, CF_DEFAULT)
-    check e1.isOk() and e1.value == false
-    d = db.delete(otherKey, CF_DEFAULT)
-    check d.isOk()
-
-    var d2 = db.delete(key, CF_OTHER)
-    check d2.isOk()
-    e3 = db.keyExists(key, CF_OTHER)
-    check e3.isOk() and e3.value == false
-    d2 = db.delete(otherKey, CF_OTHER)
-    check d2.isOk()
-    d2 = db.delete(otherKey, CF_OTHER)
-    check d2.isOk()
 
     db.close()
     check db.isClosed()
@@ -179,20 +137,101 @@ suite "RocksDbRef Tests":
     # Open database in read only mode
     block:
       var
-        readOnlyDb = initReadOnlyDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+        readOnlyDb = initReadOnlyDb(dbPath, columnFamilyNames = @[CF_DEFAULT])
+        r = readOnlyDb.keyExists(key)
+      check r.isOk() and r.value == false
 
-      var r = readOnlyDb.keyExists(key, CF_OTHER)
+      # Won't compile as designed:
+      # var r2 = readOnlyDb.put(key, @[123.byte], defaultCfHandle)
+      # check r2.isErr()
+
+      readOnlyDb.close()
+      check readOnlyDb.isClosed()
+
+  test "Basic operations - multiple column families":
+    var s = db.put(key, val, defaultCfHandle)
+    check s.isOk()
+
+    var s2 = db.put(otherKey, val, otherCfHandle)
+    check s2.isOk()
+
+    var bytes: seq[byte]
+    check db.get(
+      key,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+      defaultCfHandle,
+    )[]
+    check not db.get(
+      otherKey,
+      proc(data: openArray[byte]) =
+        bytes = @data
+      ,
+      defaultCfHandle,
+    )[]
+
+    var bytes2: seq[byte]
+    check db.get(
+      otherKey,
+      proc(data: openArray[byte]) =
+        bytes2 = @data
+      ,
+      otherCfHandle,
+    )[]
+    check not db.get(
+      key,
+      proc(data: openArray[byte]) =
+        bytes2 = @data
+      ,
+      otherCfHandle,
+    )[]
+
+    var e1 = db.keyExists(key, defaultCfHandle)
+    check e1.isOk() and e1.value == true
+    var e2 = db.keyExists(otherKey, defaultCfHandle)
+    check e2.isOk() and e2.value == false
+
+    var e3 = db.keyExists(key, otherCfHandle)
+    check e3.isOk() and e3.value == false
+    var e4 = db.keyExists(otherKey, otherCfHandle)
+    check e4.isOk() and e4.value == true
+
+    var d = db.delete(key, defaultCfHandle)
+    check d.isOk()
+    e1 = db.keyExists(key, defaultCfHandle)
+    check e1.isOk() and e1.value == false
+    d = db.delete(otherKey, defaultCfHandle)
+    check d.isOk()
+
+    var d2 = db.delete(key, otherCfHandle)
+    check d2.isOk()
+    e3 = db.keyExists(key, otherCfHandle)
+    check e3.isOk() and e3.value == false
+    d2 = db.delete(otherKey, otherCfHandle)
+    check d2.isOk()
+    d2 = db.delete(otherKey, otherCfHandle)
+    check d2.isOk()
+
+    db.close()
+    check db.isClosed()
+
+    # Open database in read only mode
+    block:
+      var readOnlyDb =
+        initReadOnlyDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+
+      var r = readOnlyDb.keyExists(key, readOnlyDb.getColFamilyHandle(CF_OTHER).get())
       check r.isOk() and r.value == false
 
       # Does not compile as designed:
-      # var r2 = readOnlyDb.put(key, @[123.byte], CF_OTHER)
+      # var r2 = readOnlyDb.put(key, @[123.byte], otherCfHandle)
       # check r2.isErr()
 
       readOnlyDb.close()
       check readOnlyDb.isClosed()
 
   test "Close multiple times":
-
     check not db.isClosed()
     db.close()
     check db.isClosed()
@@ -201,19 +240,8 @@ suite "RocksDbRef Tests":
 
   test "Unknown column family":
     const CF_UNKNOWN = "unknown"
-
-    let r = db.put(key, val, CF_UNKNOWN)
-    check r.isErr() and r.error() == "rocksdb: unknown column family"
-
-    var bytes: seq[byte]
-    let r2 = db.get(key, proc(data: openArray[byte]) = bytes = @data, CF_UNKNOWN)
-    check r2.isErr() and r2.error() == "rocksdb: unknown column family"
-
-    let r3 = db.keyExists(key, CF_UNKNOWN)
-    check r3.isErr() and r3.error() == "rocksdb: unknown column family"
-
-    let r4 = db.delete(key, CF_UNKNOWN)
-    check r4.isErr() and r4.error() == "rocksdb: unknown column family"
+    let cfHandleRes = db.getColFamilyHandle(CF_UNKNOWN)
+    check cfHandleRes.isErr() and cfHandleRes.error() == "rocksdb: unknown column family"
 
   test "Test missing key and values":
     let
@@ -240,7 +268,12 @@ suite "RocksDbRef Tests":
 
     block:
       var v: seq[byte]
-      let r = db.get(key1, proc(data: openArray[byte]) = v = @data)
+      let r = db.get(
+        key1,
+        proc(data: openArray[byte]) =
+          v = @data
+        ,
+      )
       check:
         r.isOk()
         r.value() == true
@@ -249,7 +282,12 @@ suite "RocksDbRef Tests":
 
     block:
       var v: seq[byte]
-      let r = db.get(key2, proc(data: openArray[byte]) = v = @data)
+      let r = db.get(
+        key2,
+        proc(data: openArray[byte]) =
+          v = @data
+        ,
+      )
       check:
         r.isOk()
         r.value() == true
@@ -258,7 +296,12 @@ suite "RocksDbRef Tests":
 
     block:
       var v: seq[byte]
-      let r = db.get(key3, proc(data: openArray[byte]) = v = @data)
+      let r = db.get(
+        key3,
+        proc(data: openArray[byte]) =
+          v = @data
+        ,
+      )
       check:
         r.isOk()
         r.value() == true
@@ -267,7 +310,12 @@ suite "RocksDbRef Tests":
 
     block:
       var v: seq[byte]
-      let r = db.get(key4, proc(data: openArray[byte]) = v = @data)
+      let r = db.get(
+        key4,
+        proc(data: openArray[byte]) =
+          v = @data
+        ,
+      )
       check:
         r.isOk()
         r.value() == false
@@ -276,7 +324,12 @@ suite "RocksDbRef Tests":
 
     block:
       var v: seq[byte]
-      let r = db.get(key5, proc(data: openArray[byte]) = v = @data)
+      let r = db.get(
+        key5,
+        proc(data: openArray[byte]) =
+          v = @data
+        ,
+      )
       check:
         r.isOk()
         r.value() == false

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -152,6 +152,7 @@ suite "RocksDbRef Tests":
     var s = db.put(key, val, defaultCfHandle)
     check s.isOk()
 
+    var s2 = db.put(otherKey, val, otherCfHandle)
     check s2.isOk()
 
     var bytes: seq[byte]

--- a/tests/test_sstfilewriter.nim
+++ b/tests/test_sstfilewriter.nim
@@ -9,15 +9,9 @@
 
 {.used.}
 
-import
-  std/os,
-  tempfile,
-  unittest2,
-  ../rocksdb/[rocksdb, sstfilewriter],
-  ./test_helper
+import std/os, tempfile, unittest2, ../rocksdb/[rocksdb, sstfilewriter], ./test_helper
 
 suite "SstFileWriterRef Tests":
-
   const
     CF_DEFAULT = "default"
     CF_OTHER = "other"
@@ -34,8 +28,9 @@ suite "SstFileWriterRef Tests":
     let
       dbPath = mkdtemp() / "data"
       sstFilePath = mkdtemp() / "sst"
-      db = initReadWriteDb(dbPath,
-        columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+      db = initReadWriteDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+      defaultCfHandle = db.getColFamilyHandle(CF_DEFAULT).get()
+      otherCfHandle = db.getColFamilyHandle(CF_OTHER).get()
 
   teardown:
     db.close()
@@ -45,7 +40,8 @@ suite "SstFileWriterRef Tests":
     let res = openSstFileWriter(sstFilePath)
     check res.isOk()
     let writer = res.get()
-    defer: writer.close()
+    defer:
+      writer.close()
 
     check:
       writer.put(key1, val1).isOk()
@@ -63,7 +59,8 @@ suite "SstFileWriterRef Tests":
     let res = openSstFileWriter(sstFilePath)
     check res.isOk()
     let writer = res.get()
-    defer: writer.close()
+    defer:
+      writer.close()
 
     check:
       writer.put(key1, val1).isOk()
@@ -71,13 +68,13 @@ suite "SstFileWriterRef Tests":
       writer.put(key3, val3).isOk()
       writer.finish().isOk()
 
-      db.ingestExternalFile(sstFilePath, CF_OTHER).isOk()
-      db.keyExists(key1, CF_DEFAULT).get() == false
-      db.keyExists(key2, CF_DEFAULT).get() == false
-      db.keyExists(key3, CF_DEFAULT).get() == false
-      db.get(key1, CF_OTHER).get() == val1
-      db.get(key2, CF_OTHER).get() == val2
-      db.get(key3, CF_OTHER).get() == val3
+      db.ingestExternalFile(sstFilePath, otherCfHandle).isOk()
+      db.keyExists(key1, defaultCfHandle).get() == false
+      db.keyExists(key2, defaultCfHandle).get() == false
+      db.keyExists(key3, defaultCfHandle).get() == false
+      db.get(key1, otherCfHandle).get() == val1
+      db.get(key2, otherCfHandle).get() == val2
+      db.get(key3, otherCfHandle).get() == val3
 
   test "Test close":
     let res = openSstFileWriter(sstFilePath)

--- a/tests/test_writebatch.nim
+++ b/tests/test_writebatch.nim
@@ -9,15 +9,9 @@
 
 {.used.}
 
-import
-  std/os,
-  tempfile,
-  unittest2,
-  ../rocksdb/[rocksdb, writebatch],
-  ./test_helper
+import std/os, tempfile, unittest2, ../rocksdb/[rocksdb, writebatch], ./test_helper
 
 suite "WriteBatchRef Tests":
-
   const
     CF_DEFAULT = "default"
     CF_OTHER = "other"
@@ -31,8 +25,11 @@ suite "WriteBatchRef Tests":
     val3 = @[byte(3)]
 
   setup:
-    let dbPath = mkdtemp() / "data"
-    var db = initReadWriteDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+    let
+      dbPath = mkdtemp() / "data"
+      db = initReadWriteDb(dbPath, columnFamilyNames = @[CF_DEFAULT, CF_OTHER])
+      defaultCfHandle = db.getColFamilyHandle(CF_DEFAULT).get()
+      otherCfHandle = db.getColFamilyHandle(CF_OTHER).get()
 
   teardown:
     db.close()
@@ -40,7 +37,8 @@ suite "WriteBatchRef Tests":
 
   test "Test writing batch to the default column family":
     var batch = db.openWriteBatch()
-    defer: batch.close()
+    defer:
+      batch.close()
     check not batch.isClosed()
 
     check:
@@ -67,55 +65,27 @@ suite "WriteBatchRef Tests":
       not batch.isClosed()
 
   test "Test writing batch to column family":
-    var batch = db.openWriteBatch()
-    defer: batch.close()
-    check not batch.isClosed()
-
-    check:
-      batch.put(key1, val1, CF_OTHER).isOk()
-      batch.put(key2, val2, CF_OTHER).isOk()
-      batch.put(key3, val3, CF_OTHER).isOk()
-      batch.count() == 3
-
-      batch.delete(key2, CF_OTHER).isOk()
-      batch.count() == 4
-      not batch.isClosed()
-
-    let res = db.write(batch)
-    check:
-      res.isOk()
-      db.get(key1, CF_OTHER).get() == val1
-      db.keyExists(key2, CF_OTHER).get() == false
-      db.get(key3, CF_OTHER).get() == val3
-
-    batch.clear()
-    check:
-      batch.count() == 0
-      not batch.isClosed()
-
-  test "Test writing to multiple column families in single batch":
-    var batch = db.openWriteBatch()
-    defer: batch.close()
+    var batch = db.openWriteBatch(otherCfHandle)
+    defer:
+      batch.close()
     check not batch.isClosed()
 
     check:
       batch.put(key1, val1).isOk()
-      batch.put(key1, val1, CF_OTHER).isOk()
-      batch.put(key2, val2, CF_OTHER).isOk()
-      batch.put(key3, val3, CF_OTHER).isOk()
-      batch.count() == 4
+      batch.put(key2, val2).isOk()
+      batch.put(key3, val3).isOk()
+      batch.count() == 3
 
-      batch.delete(key2, CF_OTHER).isOk()
-      batch.count() == 5
+      batch.delete(key2).isOk()
+      batch.count() == 4
       not batch.isClosed()
 
     let res = db.write(batch)
     check:
       res.isOk()
-      db.get(key1).get() == val1
-      db.get(key1, CF_OTHER).get() == val1
-      db.keyExists(key2, CF_OTHER).get() == false
-      db.get(key3, CF_OTHER).get() == val3
+      db.get(key1, otherCfHandle).get() == val1
+      db.keyExists(key2, otherCfHandle).get() == false
+      db.get(key3, otherCfHandle).get() == val3
 
     batch.clear()
     check:
@@ -123,21 +93,25 @@ suite "WriteBatchRef Tests":
       not batch.isClosed()
 
   test "Test writing to multiple column families in multiple batches":
-    var batch1 = db.openWriteBatch()
-    defer: batch1.close()
+    var batch1 = db.openWriteBatch(defaultCfHandle)
+    defer:
+      batch1.close()
     check not batch1.isClosed()
 
-    var batch2 = db.openWriteBatch()
-    defer: batch2.close()
+    var batch2 = db.openWriteBatch(otherCfHandle)
+    defer:
+      batch2.close()
     check not batch2.isClosed()
 
     check:
       batch1.put(key1, val1).isOk()
-      batch1.delete(key2, CF_OTHER).isOk()
-      batch1.put(key3, val3, CF_OTHER).isOk()
-      batch2.put(key1, val1, CF_OTHER).isOk()
-      batch2.delete(key1, CF_OTHER).isOk()
+      batch1.delete(key2).isOk()
+      batch1.put(key3, val3).isOk()
+
+      batch2.put(key1, val1).isOk()
+      batch2.delete(key1).isOk()
       batch2.put(key3, val3).isOk()
+
       batch1.count() == 3
       batch2.count() == 3
 
@@ -149,26 +123,14 @@ suite "WriteBatchRef Tests":
       db.get(key1).get() == val1
       db.keyExists(key2).get() == false
       db.get(key3).get() == val3
-      db.keyExists(key1, CF_OTHER).get() == false
-      db.keyExists(key2, CF_OTHER).get() == false
-      db.get(key3, CF_OTHER).get() == val3
-
-  test "Test unknown column family":
-    const CF_UNKNOWN = "unknown"
-
-    var batch = db.openWriteBatch()
-    defer: batch.close()
-    check not batch.isClosed()
-
-    let r = batch.put(key1, val1, CF_UNKNOWN)
-    check r.isErr() and r.error() == "rocksdb: unknown column family"
-
-    let r2 = batch.delete(key1, CF_UNKNOWN)
-    check r2.isErr() and r2.error() == "rocksdb: unknown column family"
+      db.keyExists(key1, otherCfHandle).get() == false
+      db.keyExists(key2, otherCfHandle).get() == false
+      db.get(key3, otherCfHandle).get() == val3
 
   test "Test write empty batch":
     var batch = db.openWriteBatch()
-    defer: batch.close()
+    defer:
+      batch.close()
     check not batch.isClosed()
 
     check batch.count() == 0


### PR DESCRIPTION
Changes in this PR:
- RocksDb, ColFamily, TransactionDb and Transaction types all updated to take a ColFamilyHandleRef instead of column family string.
- We are still using column family name string when opening the database as is required.
- After opening the database we need to call `db.getColFamilyHandle(name)` to get the handle by name which can then be used to read and/or write to that column family in the database.

Note: This is a breaking change to the API so I've bumped the version to v0.5.0.