### PR TITLE
Remove support for nim v1.6.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [version-1-6, version-2-0, devel]
+        branch: [version-2-0, devel]
         include:
           - target:
               os: linux
@@ -59,7 +59,7 @@ jobs:
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
-    #continue-on-error: ${{ matrix.branch == 'version-1-6' || matrix.branch == 'devel' }}
+    #continue-on-error: ${{ matrix.branch == 'version-2-0' || matrix.branch == 'devel' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -8,7 +8,7 @@ skipDirs = @["examples", "tests"]
 mode = ScriptMode.Verbose
 
 ### Dependencies
-requires "nim >= 1.6", "results", "tempfile", "unittest2"
+requires "nim >= 2.0", "results", "tempfile", "unittest2"
 
 # Format only works with nim version 2
 task format, "Format nim code using nph":


### PR DESCRIPTION
Is there any reason we should still support nim v1.6 for RocksDb?