### PR TITLE
Auto close feature to improve memory management of option types.

### DIFF
--- a/rocksdb/backup.nim
+++ b/rocksdb/backup.nim
@@ -30,6 +30,10 @@ proc openBackupEngine*(
   ## Create a new backup engine. The `path` parameter is the path of the backup
   ## directory. Note that the same directory should not be used for both backups
   ## and the database itself.
+  ##
+  ## If no `backupOpts` are provided, the default options will be used. These
+  ## default backup options will be closed when the backup engine is closed.
+  ## If `backupOpts` are provided, they will need to be closed manually.
 
   var errors: cstring
   let backupEnginePtr = rocksdb_backup_engine_open(

--- a/rocksdb/columnfamily/cfdescriptor.nim
+++ b/rocksdb/columnfamily/cfdescriptor.nim
@@ -9,16 +9,18 @@
 
 {.push raises: [].}
 
-import ../internal/utils, ./cfopts
+import ./cfopts
 
 export cfopts
+
+const DEFAULT_COLUMN_FAMILY_NAME* = "default"
 
 type ColFamilyDescriptor* = object
   name: string
   options: ColFamilyOptionsRef
 
 proc initColFamilyDescriptor*(
-    name: string, options = defaultColFamilyOptions()
+    name: string, options: ColFamilyOptionsRef
 ): ColFamilyDescriptor =
   ColFamilyDescriptor(name: name, options: options)
 
@@ -28,11 +30,16 @@ proc name*(descriptor: ColFamilyDescriptor): string {.inline.} =
 proc options*(descriptor: ColFamilyDescriptor): ColFamilyOptionsRef {.inline.} =
   descriptor.options
 
+proc autoClose*(descriptor: ColFamilyDescriptor): bool {.inline.} =
+  descriptor.options.autoClose
+
 proc isDefault*(descriptor: ColFamilyDescriptor): bool {.inline.} =
   descriptor.name == DEFAULT_COLUMN_FAMILY_NAME
 
-proc defaultColFamilyDescriptor*(): ColFamilyDescriptor {.inline.} =
-  initColFamilyDescriptor(DEFAULT_COLUMN_FAMILY_NAME)
+proc defaultColFamilyDescriptor*(autoClose = false): ColFamilyDescriptor {.inline.} =
+  initColFamilyDescriptor(
+    DEFAULT_COLUMN_FAMILY_NAME, defaultColFamilyOptions(autoClose = autoClose)
+  )
 
 proc isClosed*(descriptor: ColFamilyDescriptor): bool {.inline.} =
   descriptor.options.isClosed()

--- a/rocksdb/columnfamily/cfopts.nim
+++ b/rocksdb/columnfamily/cfopts.nim
@@ -23,6 +23,7 @@ type
     # type - CF options are a subset of rocksdb_options_t - when in doubt, check:
     # https://github.com/facebook/rocksdb/blob/b8c9a2576af6a1d0ffcfbb517dfcb7e7037bd460/include/rocksdb/options.h#L66
     cPtr: ColFamilyOptionsPtr
+    autoClose*: bool # if true then close will be called when the database is closed
 
   Compression* {.pure.} = enum
     # Use a slightly clunky name here to avoid global symbol conflicts
@@ -50,8 +51,8 @@ proc close*(s: SlicetransformRef) =
     rocksdb_slicetransform_destroy(s.cPtr)
     s.cPtr = nil
 
-proc newColFamilyOptions*(): ColFamilyOptionsRef =
-  ColFamilyOptionsRef(cPtr: rocksdb_options_create())
+proc newColFamilyOptions*(autoClose = false): ColFamilyOptionsRef =
+  ColFamilyOptionsRef(cPtr: rocksdb_options_create(), autoClose: autoClose)
 
 proc isClosed*(cfOpts: ColFamilyOptionsRef): bool {.inline.} =
   cfOpts.cPtr.isNil()
@@ -114,8 +115,8 @@ opt blobGCForceThreshold, float, cdouble
 opt blobCompactionReadaheadSize, int, uint64
 opt blobFileStartingLevel, int, cint
 
-proc defaultColFamilyOptions*(): ColFamilyOptionsRef =
-  newColFamilyOptions()
+proc defaultColFamilyOptions*(autoClose = false): ColFamilyOptionsRef =
+  newColFamilyOptions(autoClose)
 
 # proc setFixedPrefixExtractor*(dbOpts: ColFamilyOptionsRef, length: int) =
 #   doAssert not dbOpts.isClosed()

--- a/rocksdb/internal/utils.nim
+++ b/rocksdb/internal/utils.nim
@@ -21,29 +21,29 @@ proc createLock*(): Lock =
   initLock(lock)
   lock
 
+template autoCloseNonNil*(opts: typed) =
+  if not opts.isNil and opts.autoClose:
+    opts.close()
+
 template bailOnErrors*(
     errors: cstring,
     dbOpts: DbOptionsRef = nil,
     readOpts: ReadOptionsRef = nil,
     writeOpts: WriteOptionsRef = nil,
     txDbOpts: TransactionDbOptionsRef = nil,
-    cfDescriptors: openArray[ColFamilyDescriptor] = [],
     backupOpts: BackupEngineOptionsRef = nil,
+    cfDescriptors: openArray[ColFamilyDescriptor] = @[],
 ): auto =
   if not errors.isNil:
-    if not dbOpts.isNil() and dbOpts.autoClose:
-      dbOpts.close()
-    if not readOpts.isNil() and dbOpts.autoClose:
-      readOpts.close()
-    if not writeOpts.isNil() and dbOpts.autoClose:
-      writeOpts.close()
-    if not txDbOpts.isNil() and dbOpts.autoClose:
-      txDbOpts.close()
+    autoCloseNonNil(dbOpts)
+    autoCloseNonNil(readOpts)
+    autoCloseNonNil(writeOpts)
+    autoCloseNonNil(txDbOpts)
+    autoCloseNonNil(backupOpts)
+
     for cfDesc in cfDescriptors:
       if cfDesc.autoClose:
         cfDesc.close()
-    if not backupOpts.isNil() and backupOpts.autoClose:
-      backupOpts.close()
 
     let res = err($(errors))
     rocksdb_free(errors)

--- a/rocksdb/internal/utils.nim
+++ b/rocksdb/internal/utils.nim
@@ -32,13 +32,13 @@ template bailOnErrors*(
     txDbOpts: TransactionDbOptionsRef = nil,
 ): auto =
   if not errors.isNil:
-    if not dbOpts.isNil():
+    if not dbOpts.isNil() and dbOpts.autoClose:
       dbOpts.close()
-    if not readOpts.isNil():
+    if not readOpts.isNil() and dbOpts.autoClose:
       readOpts.close()
-    if not writeOpts.isNil():
+    if not writeOpts.isNil() and dbOpts.autoClose:
       writeOpts.close()
-    if not txDbOpts.isNil():
+    if not txDbOpts.isNil() and dbOpts.autoClose:
       txDbOpts.close()
 
     let res = err($(errors))

--- a/rocksdb/options/backupopts.nim
+++ b/rocksdb/options/backupopts.nim
@@ -16,9 +16,10 @@ type
 
   BackupEngineOptionsRef* = ref object
     cPtr: BackupEngineOptionsPtr
+    autoClose*: bool # if true then close will be called when the backup engine is closed
 
-proc newBackupEngineOptions*(): BackupEngineOptionsRef =
-  BackupEngineOptionsRef(cPtr: rocksdb_options_create())
+proc newBackupEngineOptions*(autoClose = false): BackupEngineOptionsRef =
+  BackupEngineOptionsRef(cPtr: rocksdb_options_create(), autoClose: autoClose)
 
 proc isClosed*(engineOpts: BackupEngineOptionsRef): bool {.inline.} =
   engineOpts.cPtr.isNil()
@@ -29,8 +30,11 @@ proc cPtr*(engineOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-proc defaultBackupEngineOptions*(): BackupEngineOptionsRef {.inline.} =
-  let opts = newBackupEngineOptions()
+proc defaultBackupEngineOptions*(autoClose = false): BackupEngineOptionsRef {.inline.} =
+  let opts = newBackupEngineOptions(autoClose)
+
+  # TODO: set defaults here
+
   opts
 
 proc close*(engineOpts: BackupEngineOptionsRef) =

--- a/rocksdb/options/dbopts.nim
+++ b/rocksdb/options/dbopts.nim
@@ -18,9 +18,10 @@ type
 
   DbOptionsRef* = ref object
     cPtr: DbOptionsPtr
+    autoClose*: bool # if true then close will be called when the database is closed
 
-proc newDbOptions*(): DbOptionsRef =
-  DbOptionsRef(cPtr: rocksdb_options_create())
+proc newDbOptions*(autoClose = false): DbOptionsRef =
+  DbOptionsRef(cPtr: rocksdb_options_create(), autoClose: autoClose)
 
 proc isClosed*(dbOpts: DbOptionsRef): bool {.inline.} =
   dbOpts.cPtr.isNil()
@@ -95,8 +96,8 @@ proc `rowCache=`*(dbOpts: DbOptionsRef, cache: CacheRef) =
   doAssert not dbOpts.isClosed()
   rocksdb_options_set_row_cache(dbOpts.cPtr, cache.cPtr)
 
-proc defaultDbOptions*(): DbOptionsRef =
-  let opts: DbOptionsRef = newDbOptions()
+proc defaultDbOptions*(autoClose = false): DbOptionsRef =
+  let opts: DbOptionsRef = newDbOptions(autoClose)
 
   # Optimize RocksDB. This is the easiest way to get RocksDB to perform well:
   opts.increaseParallelism(countProcessors())

--- a/rocksdb/options/readopts.nim
+++ b/rocksdb/options/readopts.nim
@@ -16,9 +16,10 @@ type
 
   ReadOptionsRef* = ref object
     cPtr: ReadOptionsPtr
+    autoClose*: bool # if true then close will be called when the database is closed
 
-proc newReadOptions*(): ReadOptionsRef =
-  ReadOptionsRef(cPtr: rocksdb_readoptions_create())
+proc newReadOptions*(autoClose = false): ReadOptionsRef =
+  ReadOptionsRef(cPtr: rocksdb_readoptions_create(), autoClose: autoClose)
 
 proc isClosed*(readOpts: ReadOptionsRef): bool {.inline.} =
   readOpts.cPtr.isNil()
@@ -29,8 +30,8 @@ proc cPtr*(readOpts: ReadOptionsRef): ReadOptionsPtr =
 
 # TODO: Add setters and getters for read options properties.
 
-proc defaultReadOptions*(): ReadOptionsRef {.inline.} =
-  newReadOptions()
+proc defaultReadOptions*(autoClose = false): ReadOptionsRef {.inline.} =
+  newReadOptions(autoClose)
   # TODO: set prefered defaults
 
 proc close*(readOpts: ReadOptionsRef) =

--- a/rocksdb/options/writeopts.nim
+++ b/rocksdb/options/writeopts.nim
@@ -16,9 +16,10 @@ type
 
   WriteOptionsRef* = ref object
     cPtr: WriteOptionsPtr
+    autoClose*: bool # if true then close will be called when the database is closed
 
-proc newWriteOptions*(): WriteOptionsRef =
-  WriteOptionsRef(cPtr: rocksdb_writeoptions_create())
+proc newWriteOptions*(autoClose = false): WriteOptionsRef =
+  WriteOptionsRef(cPtr: rocksdb_writeoptions_create(), autoClose: autoClose)
 
 proc isClosed*(writeOpts: WriteOptionsRef): bool {.inline.} =
   writeOpts.cPtr.isNil()
@@ -29,8 +30,8 @@ proc cPtr*(writeOpts: WriteOptionsRef): WriteOptionsPtr =
 
 # TODO: Add setters and getters for write options properties.
 
-proc defaultWriteOptions*(): WriteOptionsRef {.inline.} =
-  newWriteOptions()
+proc defaultWriteOptions*(autoClose = false): WriteOptionsRef {.inline.} =
+  newWriteOptions(autoClose)
   # TODO: set prefered defaults
 
 proc close*(writeOpts: WriteOptionsRef) =

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -124,7 +124,7 @@ proc openRocksDb*(
     cfHandles[0].addr,
     cast[cstringArray](errors.addr),
   )
-  bailOnErrors(errors)
+  bailOnErrors(errors, dbOpts, readOpts, writeOpts)
 
   let
     cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)
@@ -174,7 +174,7 @@ proc openRocksDbReadOnly*(
     errorIfWalFileExists.uint8,
     cast[cstringArray](errors.addr),
   )
-  bailOnErrors(errors)
+  bailOnErrors(errors, dbOpts, readOpts)
 
   let
     cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -102,6 +102,9 @@ proc openRocksDb*(
   ## Open a RocksDB instance in read-write mode. If `columnFamilies` is empty
   ## then it will open the default column family. If `dbOpts`, `readOpts`, or
   ## `writeOpts` are not supplied then the default options will be used.
+  ## These default options will be closed when the database is closed.
+  ## If any options are provided, they will need to be closed manually.
+  ##
   ## By default, column families will be created if they don't yet exist.
   ## All existing column families must be specified if the database has
   ## previously created any column families.
@@ -151,10 +154,13 @@ proc openRocksDbReadOnly*(
 ): RocksDBResult[RocksDbReadOnlyRef] =
   ## Open a RocksDB instance in read-only mode. If `columnFamilies` is empty
   ## then it will open the default column family. If `dbOpts` or `readOpts` are
-  ## not supplied then the default options will be used. By default, column
-  ## families will be created if they don't yet exist. If the database already
-  ## contains any column families, then all or a subset of the existing column
-  ## families can be opened for reading.
+  ## not supplied then the default options will be used.
+  ## These default options will be closed when the database is closed.
+  ## If any options are provided, they will need to be closed manually.
+  ##
+  ## By default, column families will be created if they don't yet exist.
+  ## If the database already contains any column families, then all or
+  ## a subset of the existing column families can be opened for reading.
 
   var cfs = columnFamilies.toSeq()
   if DEFAULT_COLUMN_FAMILY_NAME notin columnFamilies.mapIt(it.name()):

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -46,8 +46,7 @@ proc seekToKey*(iter: RocksIteratorRef, key: openArray[byte]) =
   ##    invalid.
   ##
   doAssert not iter.isClosed()
-  let (cKey, cLen) = (cast[cstring](unsafeAddr key[0]), csize_t(key.len))
-  rocksdb_iter_seek(iter.cPtr, cKey, cLen)
+  rocksdb_iter_seek(iter.cPtr, cast[cstring](unsafeAddr key[0]), csize_t(key.len))
 
 proc seekToFirst*(iter: RocksIteratorRef) =
   ## Seeks to the first entry in the column family.

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -28,6 +28,9 @@ proc openSstFileWriter*(
     filePath: string, dbOpts = defaultDbOptions(autoClose = true)
 ): RocksDBResult[SstFileWriterRef] =
   ## Creates a new `SstFileWriterRef` and opens the file at the given `filePath`.
+  ## If `dbOpts` is not supplied then the default options will be used.
+  ## These default options will be closed when the file writer is closed.
+  ## If any options are provided, they will need to be closed manually.
   doAssert not dbOpts.isClosed()
 
   let envOptsPtr = rocksdb_envoptions_create()

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -25,10 +25,9 @@ type
     dbOpts: DbOptionsRef
 
 proc openSstFileWriter*(
-    filePath: string, dbOpts = DbOptionsRef(nil)
+    filePath: string, dbOpts = defaultDbOptions()
 ): RocksDBResult[SstFileWriterRef] =
   ## Creates a new `SstFileWriterRef` and opens the file at the given `filePath`.
-  let dbOpts = (if dbOpts.isNil: defaultDbOptions() else: dbOpts)
   doAssert not dbOpts.isClosed()
 
   let envOptsPtr = rocksdb_envoptions_create()
@@ -95,6 +94,7 @@ proc finish*(writer: SstFileWriterRef): RocksDBResult[void] =
 proc close*(writer: SstFileWriterRef) =
   ## Closes the `SstFileWriterRef`.
   if not writer.isClosed():
+    writer.dbOpts.close()
     rocksdb_envoptions_destroy(writer.envOptsPtr)
     writer.envOptsPtr = nil
     rocksdb_sstfilewriter_destroy(writer.cPtr)

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -117,11 +117,15 @@ proc beginTransaction*(
 
 proc close*(db: TransactionDbRef) =
   ## Close the `TransactionDbRef`.
+
   withLock(db.lock):
     if not db.isClosed():
-      db.dbOpts.close()
-      db.txDbOpts.close()
+      # the column families should be closed before the database
       db.cfTable.close()
 
       rocksdb_transactiondb_close(db.cPtr)
       db.cPtr = nil
+
+      # opts should be closed after the database is closed
+      db.dbOpts.close()
+      db.txDbOpts.close()

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -107,6 +107,8 @@ proc beginTransaction*(
   ## Begin a new transaction against the database. The transaction will default
   ## to using the specified column family. If no column family is specified
   ## then the default column family will be used.
+  ##
+  ## The opts types will be closed when the transaction is closed.
   doAssert not db.isClosed()
 
   let txPtr = rocksdb_transaction_begin(db.cPtr, writeOpts.cPtr, txOpts.cPtr, nil)

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -49,6 +49,8 @@ proc openTransactionDb*(
   ## Open a `TransactionDbRef` with the given options and column families.
   ## If no column families are provided the default column family will be used.
   ## If no options are provided the default options will be used.
+  ## These default options will be closed when the database is closed.
+  ## If any options are provided, they will need to be closed manually.
 
   var cfs = columnFamilies.toSeq()
   if DEFAULT_COLUMN_FAMILY_NAME notin columnFamilies.mapIt(it.name()):

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -41,8 +41,8 @@ type
 
 proc openTransactionDb*(
     path: string,
-    dbOpts = defaultDbOptions(),
-    txDbOpts = defaultTransactionDbOptions(),
+    dbOpts = defaultDbOptions(autoClose = true),
+    txDbOpts = defaultTransactionDbOptions(autoClose = true),
     columnFamilies: openArray[ColFamilyDescriptor] = [],
 ): RocksDBResult[TransactionDbRef] =
   ## Open a `TransactionDbRef` with the given options and column families.
@@ -99,9 +99,9 @@ proc isClosed*(db: TransactionDbRef): bool {.inline.} =
 
 proc beginTransaction*(
     db: TransactionDbRef,
-    readOpts = defaultReadOptions(),
-    writeOpts = defaultWriteOptions(),
-    txOpts = defaultTransactionOptions(),
+    readOpts = defaultReadOptions(autoClose = true),
+    writeOpts = defaultWriteOptions(autoClose = true),
+    txOpts = defaultTransactionOptions(autoClose = true),
     cfHandle = db.defaultCfHandle,
 ): TransactionRef =
   ## Begin a new transaction against the database. The transaction will default
@@ -127,5 +127,7 @@ proc close*(db: TransactionDbRef) =
       db.cPtr = nil
 
       # opts should be closed after the database is closed
-      db.dbOpts.close()
-      db.txDbOpts.close()
+      if db.dbOpts.autoClose:
+        db.dbOpts.close()
+      if db.txDbOpts.autoClose:
+        db.txDbOpts.close()

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -69,7 +69,7 @@ proc openTransactionDb*(
     cfHandles[0].addr,
     cast[cstringArray](errors.addr),
   )
-  bailOnErrors(errors)
+  bailOnErrors(errors, dbOpts, txDbOpts = txDbOpts)
 
   let
     cfTable = newColFamilyTable(cfNames.mapIt($it), cfHandles)

--- a/rocksdb/transactions/transaction.nim
+++ b/rocksdb/transactions/transaction.nim
@@ -175,9 +175,13 @@ proc rollback*(tx: TransactionRef): RocksDBResult[void] =
 proc close*(tx: TransactionRef) =
   ## Close the `TransactionRef`.
   if not tx.isClosed():
-    tx.readOpts.close()
-    tx.writeOpts.close()
-    tx.txOpts.close()
-
     rocksdb_transaction_destroy(tx.cPtr)
     tx.cPtr = nil
+
+    # opts should be closed after the transaction is closed
+    if tx.readOpts.autoClose:
+      tx.readOpts.close()
+    if tx.writeOpts.autoClose:
+      tx.writeOpts.close()
+    if tx.txOpts.autoClose:
+      tx.txOpts.close()

--- a/rocksdb/transactions/txdbopts.nim
+++ b/rocksdb/transactions/txdbopts.nim
@@ -16,9 +16,12 @@ type
 
   TransactionDbOptionsRef* = ref object
     cPtr: TransactionDbOptionsPtr
+    autoClose*: bool # if true then close will be called when the database is closed
 
-proc newTransactionDbOptions*(): TransactionDbOptionsRef =
-  TransactionDbOptionsRef(cPtr: rocksdb_transactiondb_options_create())
+proc newTransactionDbOptions*(autoClose = false): TransactionDbOptionsRef =
+  TransactionDbOptionsRef(
+    cPtr: rocksdb_transactiondb_options_create(), autoClose: autoClose
+  )
 
 proc isClosed*(txDbOpts: TransactionDbOptionsRef): bool {.inline.} =
   txDbOpts.cPtr.isNil()
@@ -29,8 +32,10 @@ proc cPtr*(txDbOpts: TransactionDbOptionsRef): TransactionDbOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-proc defaultTransactionDbOptions*(): TransactionDbOptionsRef {.inline.} =
-  newTransactionDbOptions()
+proc defaultTransactionDbOptions*(
+    autoClose = false
+): TransactionDbOptionsRef {.inline.} =
+  newTransactionDbOptions(autoClose)
   # TODO: set prefered defaults
 
 proc close*(txDbOpts: TransactionDbOptionsRef) =

--- a/rocksdb/transactions/txopts.nim
+++ b/rocksdb/transactions/txopts.nim
@@ -16,9 +16,12 @@ type
 
   TransactionOptionsRef* = ref object
     cPtr: TransactionOptionsPtr
+    autoClose*: bool # if true then close will be called when the transaction is closed
 
-proc newTransactionOptions*(): TransactionOptionsRef =
-  TransactionOptionsRef(cPtr: rocksdb_transaction_options_create())
+proc newTransactionOptions*(autoClose = false): TransactionOptionsRef =
+  TransactionOptionsRef(
+    cPtr: rocksdb_transaction_options_create(), autoClose: autoClose
+  )
 
 proc isClosed*(txOpts: TransactionOptionsRef): bool {.inline.} =
   txOpts.cPtr.isNil()
@@ -29,8 +32,8 @@ proc cPtr*(txOpts: TransactionOptionsRef): TransactionOptionsPtr =
 
 # TODO: Add setters and getters for backup options properties.
 
-proc defaultTransactionOptions*(): TransactionOptionsRef {.inline.} =
-  newTransactionOptions()
+proc defaultTransactionOptions*(autoClose = false): TransactionOptionsRef {.inline.} =
+  newTransactionOptions(autoClose)
   # TODO: set prefered defaults
 
 proc close*(txOpts: TransactionOptionsRef) =

--- a/tests/columnfamily/test_cfdescriptor.nim
+++ b/tests/columnfamily/test_cfdescriptor.nim
@@ -9,20 +9,10 @@
 
 {.used.}
 
-import unittest2, ../../rocksdb/internal/utils, ../../rocksdb/columnfamily/cfdescriptor
+import unittest2, ../../rocksdb/columnfamily/cfdescriptor
 
 suite "ColFamilyDescriptor Tests":
   const TEST_CF_NAME = "test"
-
-  test "Test initColFamilyDescriptor":
-    var descriptor = initColFamilyDescriptor(TEST_CF_NAME)
-
-    check:
-      descriptor.name() == TEST_CF_NAME
-      not descriptor.options().isNil()
-      not descriptor.isDefault()
-
-    descriptor.close()
 
   test "Test initColFamilyDescriptor with options":
     var descriptor = initColFamilyDescriptor(TEST_CF_NAME, defaultColFamilyOptions())

--- a/tests/test_helper.nim
+++ b/tests/test_helper.nim
@@ -43,7 +43,6 @@ proc initTransactionDb*(
 ): TransactionDbRef =
   let res = openTransactionDb(
     path,
-    txDbOpts = defaultTransactionDbOptions(),
     columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)),
   )
   if res.isErr():

--- a/tests/test_helper.nim
+++ b/tests/test_helper.nim
@@ -42,8 +42,7 @@ proc initTransactionDb*(
     path: string, columnFamilyNames: openArray[string] = @[]
 ): TransactionDbRef =
   let res = openTransactionDb(
-    path,
-    columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it)),
+    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
   )
   if res.isErr():
     echo res.error()

--- a/tests/test_helper.nim
+++ b/tests/test_helper.nim
@@ -15,7 +15,10 @@ proc initReadWriteDb*(
     path: string, columnFamilyNames: openArray[string] = @[]
 ): RocksDbReadWriteRef =
   let res = openRocksDb(
-    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
+    path,
+    columnFamilies = columnFamilyNames.mapIt(
+      initColFamilyDescriptor(it, defaultColFamilyOptions(autoClose = true))
+    ),
   )
   if res.isErr():
     echo res.error()
@@ -26,7 +29,10 @@ proc initReadOnlyDb*(
     path: string, columnFamilyNames: openArray[string] = @[]
 ): RocksDbReadOnlyRef =
   let res = openRocksDbReadOnly(
-    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
+    path,
+    columnFamilies = columnFamilyNames.mapIt(
+      initColFamilyDescriptor(it, defaultColFamilyOptions(autoClose = true))
+    ),
   )
   if res.isErr():
     echo res.error()
@@ -42,7 +48,10 @@ proc initTransactionDb*(
     path: string, columnFamilyNames: openArray[string] = @[]
 ): TransactionDbRef =
   let res = openTransactionDb(
-    path, columnFamilies = columnFamilyNames.mapIt(initColFamilyDescriptor(it))
+    path,
+    columnFamilies = columnFamilyNames.mapIt(
+      initColFamilyDescriptor(it, defaultColFamilyOptions(autoClose = true))
+    ),
   )
   if res.isErr():
     echo res.error()

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -349,3 +349,22 @@ suite "RocksDbRef Tests":
     check db.isClosed()
     db.close()
     check db.isClosed()
+
+  test "Test auto close":
+    let
+      dbPath = mkdtemp() / "autoclose"
+      dbOpts = defaultDbOptions(autoClose = false)
+      readOpts = defaultReadOptions(autoClose = true)
+      db = openRocksDb(dbPath, dbOpts, readOpts).get()
+
+    check:
+      dbOpts.isClosed() == false
+      readOpts.isClosed() == false
+      db.isClosed() == false
+
+    db.close()
+
+    check:
+      dbOpts.isClosed() == false
+      readOpts.isClosed() == true
+      db.isClosed() == true

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -231,18 +231,6 @@ suite "RocksDbRef Tests":
       readOnlyDb.close()
       check readOnlyDb.isClosed()
 
-  test "Close multiple times":
-    check not db.isClosed()
-    db.close()
-    check db.isClosed()
-    db.close()
-    check db.isClosed()
-
-  test "Unknown column family":
-    const CF_UNKNOWN = "unknown"
-    let cfHandleRes = db.getColFamilyHandle(CF_UNKNOWN)
-    check cfHandleRes.isErr() and cfHandleRes.error() == "rocksdb: unknown column family"
-
   test "Test missing key and values":
     let
       key1 = @[byte(1)] # exists with non empty value
@@ -335,3 +323,25 @@ suite "RocksDbRef Tests":
         r.value() == false
         v.len() == 0
         db.get(key5).isErr()
+
+  test "List column familes":
+    let dbOpts = defaultDbOptions()
+    defer:
+      dbOpts.close()
+
+    let colFamiliesRes = listColumnFamilies(dbPath, dbOpts)
+    check:
+      colFamiliesRes.isOk()
+      colFamiliesRes.value() == @[CF_DEFAULT, CF_OTHER]
+
+  test "Unknown column family":
+    const CF_UNKNOWN = "unknown"
+    let cfHandleRes = db.getColFamilyHandle(CF_UNKNOWN)
+    check cfHandleRes.isErr() and cfHandleRes.error() == "rocksdb: unknown column family"
+
+  test "Close multiple times":
+    check not db.isClosed()
+    db.close()
+    check db.isClosed()
+    db.close()
+    check db.isClosed()

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -325,14 +325,18 @@ suite "RocksDbRef Tests":
         db.get(key5).isErr()
 
   test "List column familes":
-    let dbOpts = defaultDbOptions()
-    defer:
-      dbOpts.close()
-
-    let colFamiliesRes = listColumnFamilies(dbPath, dbOpts)
+    let cfRes1 = listColumnFamilies(dbPath)
     check:
-      colFamiliesRes.isOk()
-      colFamiliesRes.value() == @[CF_DEFAULT, CF_OTHER]
+      cfRes1.isOk()
+      cfRes1.value() == @[CF_DEFAULT, CF_OTHER]
+
+    let
+      dbPath2 = dbPath & "2"
+      db2 = initReadWriteDb(dbPath2, columnFamilyNames = @[CF_DEFAULT])
+      cfRes2 = listColumnFamilies(dbPath2)
+    check:
+      cfRes2.isOk()
+      cfRes2.value() == @[CF_DEFAULT]
 
   test "Unknown column family":
     const CF_UNKNOWN = "unknown"

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -151,7 +151,6 @@ suite "RocksIteratorRef Tests":
       iter2.key() == @[byte(3)]
       iter2.value() == @[byte(3)]
 
-
   test "Iterate forwards using seek to key":
     let res = db.openIterator(defaultCfHandle)
     check res.isOk()

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -151,6 +151,21 @@ suite "RocksIteratorRef Tests":
       iter2.key() == @[byte(3)]
       iter2.value() == @[byte(3)]
 
+
+  test "Iterate forwards using seek to key":
+    let res = db.openIterator(defaultCfHandle)
+    check res.isOk()
+
+    var iter = res.get()
+    defer:
+      iter.close()
+
+    iter.seekToKey(key2)
+    check:
+      iter.isValid()
+      iter.key() == key2
+      iter.value() == val2
+
   test "Empty column family":
     let res = db.openIterator(emptyCfHandle)
     check res.isOk()

--- a/tests/test_transactiondb.nim
+++ b/tests/test_transactiondb.nim
@@ -201,3 +201,22 @@ suite "TransactionDbRef Tests":
     check tx2.isClosed()
     tx2.close()
     check tx2.isClosed()
+
+  test "Test auto close":
+    let
+      dbPath = mkdtemp() / "autoclose"
+      dbOpts = defaultDbOptions(autoClose = false)
+      txDbOpts = defaultTransactionDbOptions(autoClose = true)
+      db = openTransactionDb(dbPath, dbOpts, txDbOpts).get()
+
+    check:
+      dbOpts.isClosed() == false
+      txDbOpts.isClosed() == false
+      db.isClosed() == false
+
+    db.close()
+
+    check:
+      dbOpts.isClosed() == false
+      txDbOpts.isClosed() == true
+      db.isClosed() == true


### PR DESCRIPTION
This change reverts some of the changes from https://github.com/status-im/nim-rocksdb/pull/48 which prevents the opts types from be closed when passed in. Currently in Nimbus the db opt types are not freed manually so there is a memory leak from what  I can tell. This change should fix the problem once we roll this version into Nimbus.

Also doing a bit of cleanup and add a few more tests.