### PR TITLE
Use the make question option to avoid rebuild on macOS

### DIFF
--- a/scripts/build_static_deps.sh
+++ b/scripts/build_static_deps.sh
@@ -32,7 +32,7 @@ export ROCKSDB_DISABLE_BZIP=1
 export PORTABLE=1
 export DEBUG_LEVEL=0
 
-if ${MAKE} -C "${ROCKSDB_LIB_DIR}" --dry-run unity.a | grep -q "unity.a' is up to date."; then
+if ${MAKE} -C "${ROCKSDB_LIB_DIR}" -q unity.a; then
   echo "RocksDb static libraries already built. Skipping build."
   exit 0
 else


### PR DESCRIPTION
There was already the earlier strange ` before the "unity.a' is up to date message on macOS, fixed by https://github.com/status-im/nim-rocksdb/pull/65

Turns out it might still not work on macOS because of certain verbosity levels.
In nimbus-eth2 a rebuild would still always occur, except when you would do `make rocksdb V=1`
We could add the `-d` flag in the rocksdb build scripts, but that adds a lot of other debug output.

So use the question option instead of dry-run + grep as the latter is more brittle, and the former is intended for this purpose.