### PR TITLE
Don't rebuild librocksdb.dll if exists

### DIFF
--- a/scripts/build_dlls_windows.sh
+++ b/scripts/build_dlls_windows.sh
@@ -14,12 +14,33 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 REPO_DIR="${PWD}"
+BUILD_DEST="${REPO_DIR}/build"
 
 git submodule update --init
+
+if [ -f "${BUILD_DEST}/librocksdb.dll" ] && \
+   [ -f "${BUILD_DEST}/version.txt" ]; then
+
+  ROCKSDB_VERSION_BEFORE=$(cat "${BUILD_DEST}/version.txt")
+
+  cd ${REPO_DIR}/vendor/rocksdb
+  ROCKSDB_VERSION_AFTER=$(${REPO_DIR}/vendor/rocksdb/build_tools/version.sh full)
+  cd ${REPO_DIR}
+
+  if [[ ${ROCKSDB_VERSION_BEFORE} == ${ROCKSDB_VERSION_AFTER} ]]; then
+    echo "RocksDb dll libraries already built. Skipping build."
+    exit 0
+  fi
+fi
+
 
 ${REPO_DIR}/vendor/vcpkg/bootstrap-vcpkg.sh -disableMetrics
 
 ${REPO_DIR}/vendor/vcpkg/vcpkg install rocksdb[lz4,zstd]:x64-windows-rocksdb --recurse --overlay-triplets=${REPO_DIR}/triplets
 
-mkdir -p ${REPO_DIR}/build
-cp ${REPO_DIR}/vendor/vcpkg/installed/x64-windows-rocksdb/bin/rocksdb-shared.dll ./build/librocksdb.dll
+mkdir -p "${BUILD_DEST}"
+cp ${REPO_DIR}/vendor/vcpkg/installed/x64-windows-rocksdb/bin/rocksdb-shared.dll ${BUILD_DEST}/librocksdb.dll
+
+cd ${REPO_DIR}/vendor/rocksdb
+${REPO_DIR}/vendor/rocksdb/build_tools/version.sh full > "${BUILD_DEST}/version.txt" 2>&1
+cd ${REPO_DIR}


### PR DESCRIPTION
This commit is to support rocksdb binary caching in nimbus-eth1 CI.

It works in this CI run
https://github.com/status-im/nimbus-eth1/actions/runs/16693627057