### PR TITLE
Support deleteRange, compactRange and multiGet on column families

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             shell: bash
           - target:
               os: windows
-            builder: windows-latest
+            builder: windows-2022
             shell: msys2 {0}
 
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             shell: bash
           - target:
               os: windows
-            builder: windows-2022
+            builder: windows-latest
             shell: msys2 {0}
 
     defaults:

--- a/rocksdb.nimble
+++ b/rocksdb.nimble
@@ -1,5 +1,5 @@
 packageName = "rocksdb"
-version = "10.4.2.0"
+version = "10.4.2.1"
 author = "Status Research & Development GmbH"
 description =
   "A wrapper for Facebook's RocksDB, an embeddable, persistent key-value store for fast storage"

--- a/rocksdb/backup.nim
+++ b/rocksdb/backup.nim
@@ -50,7 +50,7 @@ proc openBackupEngine*(
     BackupEngineRef(cPtr: backupEnginePtr, path: path, backupOpts: backupOpts)
   ok(engine)
 
-proc isClosed*(backupEngine: BackupEngineRef): bool {.inline.} =
+template isClosed*(backupEngine: BackupEngineRef): bool =
   ## Returns `true` if the `BackupEngineRef` has been closed.
   backupEngine.cPtr.isNil()
 

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -99,6 +99,18 @@ template deleteRange*(
   ## excluding endKey.
   cf.db.deleteRange(startKey, endKey, cf.handle)
 
+template compactRange*(
+    cf: ColFamilyReadWrite, startKey, endKey: openArray[byte]
+): RocksDBResult[void] =
+  ## Trigger range compaction for the given key range.
+  cf.db.compactRange(startKey, endKey, cf.handle)
+
+template suggestCompactRange*(
+    cf: ColFamilyReadWrite, startKey, endKey: openArray[byte]
+): RocksDBResult[void] =
+  ## Suggest the range to compact.
+  cf.db.suggestCompactRange(startKey, endKey, cf.handle)
+
 template openIterator*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     readOpts = defaultReadOptions(autoClose = true),

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -98,6 +98,13 @@ template delete*(
   ## Deletes the given key from the column family.
   cf.db.delete(key, cf.handle)
 
+template deleteRange*(
+    cf: ColFamilyReadWrite, startKey, endKey: openArray[byte]
+): RocksDBResult[void] =
+  ## Deletes the given key range from the column family including startKey and
+  ## excluding endKey.
+  cf.db.deleteRange(startKey, endKey, cf.handle)
+
 template openIterator*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     readOpts = defaultReadOptions(autoClose = true),

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -53,70 +53,70 @@ proc getColFamily*(
 
   ok(ColFamilyReadWrite(db: db, name: name, handle: ?db.getColFamilyHandle(name)))
 
-proc db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto {.inline.} =
+template db*(cf: ColFamilyReadOnly | ColFamilyReadWrite): auto =
   ## Returns the underlying `RocksDbReadOnlyRef` or `RocksDbReadWriteRef`.
   cf.db
 
-proc name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string {.inline.} =
+template name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string =
   ## Returns the name of the column family.
   cf.name
 
-proc handle*(
+template handle*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite
-): ColFamilyHandleRef {.inline.} =
+): ColFamilyHandleRef =
   ## Returns the name of the column family.
   cf.handle
 
-proc get*(
+template get*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite, key: openArray[byte], onData: DataProc
-): RocksDBResult[bool] {.inline.} =
+): RocksDBResult[bool] =
   ## Gets the value of the given key from the column family using the `onData`
   ## callback.
   cf.db.get(key, onData, cf.handle)
 
-proc get*(
+template get*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite, key: openArray[byte]
-): RocksDBResult[seq[byte]] {.inline.} =
+): RocksDBResult[seq[byte]] =
   ## Gets the value of the given key from the column family.
   cf.db.get(key, cf.handle)
 
-proc put*(
+template put*(
     cf: ColFamilyReadWrite, key, val: openArray[byte]
-): RocksDBResult[void] {.inline.} =
+): RocksDBResult[void] =
   ## Puts a value for the given key into the column family.
   cf.db.put(key, val, cf.handle)
 
-proc keyExists*(
+template keyExists*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite, key: openArray[byte]
-): RocksDBResult[bool] {.inline.} =
+): RocksDBResult[bool] =
   ## Checks if the given key exists in the column family.
   cf.db.keyExists(key, cf.handle)
 
-proc delete*(
+template delete*(
     cf: ColFamilyReadWrite, key: openArray[byte]
-): RocksDBResult[void] {.inline.} =
+): RocksDBResult[void] =
   ## Deletes the given key from the column family.
   cf.db.delete(key, cf.handle)
 
-proc openIterator*(
+template openIterator*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     readOpts = defaultReadOptions(autoClose = true),
-): RocksDBResult[RocksIteratorRef] {.inline.} =
+): RocksDBResult[RocksIteratorRef] =
   ## Opens an `RocksIteratorRef` for the given column family.
   cf.db.openIterator(readOpts, cf.handle)
 
-proc openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef {.inline.} =
+template openWriteBatch*(cf: ColFamilyReadWrite): WriteBatchRef =
   ## Opens a `WriteBatchRef` for the given column family.
   cf.db.openWriteBatch(cf.handle)
 
-proc openWriteBatchWithIndex*(
+template openWriteBatchWithIndex*(
     cf: ColFamilyReadWrite, reservedBytes = 0, overwriteKey = false
-): WriteBatchWIRef {.inline.} =
+): WriteBatchWIRef =
   ## Opens a `WriteBatchRef` for the given column family.
   cf.db.openWriteBatchWithIndex(reservedBytes, overwriteKey, cf.handle)
 
-proc write*(
+template write*(
     cf: ColFamilyReadWrite, updates: WriteBatchRef | WriteBatchWIRef
-): RocksDBResult[void] {.inline.} =
+): RocksDBResult[void] =
   ## Writes the updates in the `WriteBatchRef` to the column family.
   cf.db.write(updates)

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -61,9 +61,7 @@ template name*(cf: ColFamilyReadOnly | ColFamilyReadWrite): string =
   ## Returns the name of the column family.
   cf.name
 
-template handle*(
-    cf: ColFamilyReadOnly | ColFamilyReadWrite
-): ColFamilyHandleRef =
+template handle*(cf: ColFamilyReadOnly | ColFamilyReadWrite): ColFamilyHandleRef =
   ## Returns the name of the column family.
   cf.handle
 
@@ -80,9 +78,7 @@ template get*(
   ## Gets the value of the given key from the column family.
   cf.db.get(key, cf.handle)
 
-template put*(
-    cf: ColFamilyReadWrite, key, val: openArray[byte]
-): RocksDBResult[void] =
+template put*(cf: ColFamilyReadWrite, key, val: openArray[byte]): RocksDBResult[void] =
   ## Puts a value for the given key into the column family.
   cf.db.put(key, val, cf.handle)
 
@@ -92,9 +88,7 @@ template keyExists*(
   ## Checks if the given key exists in the column family.
   cf.db.keyExists(key, cf.handle)
 
-template delete*(
-    cf: ColFamilyReadWrite, key: openArray[byte]
-): RocksDBResult[void] =
+template delete*(cf: ColFamilyReadWrite, key: openArray[byte]): RocksDBResult[void] =
   ## Deletes the given key from the column family.
   cf.db.delete(key, cf.handle)
 

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -81,11 +81,10 @@ template get*(
 template multiGet*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     keys: openArray[seq[byte]],
-    onData: DataBatchProc,
     sortedInput = false,
-): RocksDBResult[void] =
+): RocksDBResult[seq[seq[byte]]] =
   ## Get a batch of values for the given set of keys.
-  cf.db.multiGet(keys, onData, sortedInput, cf.handle)
+  cf.db.multiGet(keys, sortedInput, cf.handle)
 
 template put*(cf: ColFamilyReadWrite, key, val: openArray[byte]): RocksDBResult[void] =
   ## Puts a value for the given key into the column family.

--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -78,6 +78,15 @@ template get*(
   ## Gets the value of the given key from the column family.
   cf.db.get(key, cf.handle)
 
+template multiGet*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    keys: openArray[seq[byte]],
+    onData: DataBatchProc,
+    sortedInput = false,
+): RocksDBResult[void] =
+  ## Get a batch of values for the given set of keys.
+  cf.db.multiGet(keys, onData, sortedInput, cf.handle)
+
 template put*(cf: ColFamilyReadWrite, key, val: openArray[byte]): RocksDBResult[void] =
   ## Puts a value for the given key into the column family.
   cf.db.put(key, val, cf.handle)

--- a/rocksdb/columnfamily/cfdescriptor.nim
+++ b/rocksdb/columnfamily/cfdescriptor.nim
@@ -24,25 +24,25 @@ proc initColFamilyDescriptor*(
 ): ColFamilyDescriptor =
   ColFamilyDescriptor(name: name, options: options)
 
-proc name*(descriptor: ColFamilyDescriptor): string {.inline.} =
+template name*(descriptor: ColFamilyDescriptor): string =
   descriptor.name
 
-proc options*(descriptor: ColFamilyDescriptor): ColFamilyOptionsRef {.inline.} =
+template options*(descriptor: ColFamilyDescriptor): ColFamilyOptionsRef =
   descriptor.options
 
-proc autoClose*(descriptor: ColFamilyDescriptor): bool {.inline.} =
+template autoClose*(descriptor: ColFamilyDescriptor): bool =
   descriptor.options.autoClose
 
-proc isDefault*(descriptor: ColFamilyDescriptor): bool {.inline.} =
+template isDefault*(descriptor: ColFamilyDescriptor): bool =
   descriptor.name == DEFAULT_COLUMN_FAMILY_NAME
 
-proc defaultColFamilyDescriptor*(autoClose = false): ColFamilyDescriptor {.inline.} =
+proc defaultColFamilyDescriptor*(autoClose = false): ColFamilyDescriptor =
   initColFamilyDescriptor(
     DEFAULT_COLUMN_FAMILY_NAME, defaultColFamilyOptions(autoClose = autoClose)
   )
 
-proc isClosed*(descriptor: ColFamilyDescriptor): bool {.inline.} =
+template isClosed*(descriptor: ColFamilyDescriptor): bool =
   descriptor.options.isClosed()
 
-proc close*(descriptor: ColFamilyDescriptor) {.inline.} =
+template close*(descriptor: ColFamilyDescriptor) =
   descriptor.options.close()

--- a/rocksdb/columnfamily/cfhandle.nim
+++ b/rocksdb/columnfamily/cfhandle.nim
@@ -20,7 +20,7 @@ type
 proc newColFamilyHandle*(cPtr: ColFamilyHandlePtr): ColFamilyHandleRef =
   ColFamilyHandleRef(cPtr: cPtr)
 
-proc isClosed*(handle: ColFamilyHandleRef): bool {.inline.} =
+template isClosed*(handle: ColFamilyHandleRef): bool =
   handle.cPtr.isNil()
 
 proc cPtr*(handle: ColFamilyHandleRef): ColFamilyHandlePtr =

--- a/rocksdb/columnfamily/cfopts.nim
+++ b/rocksdb/columnfamily/cfopts.nim
@@ -43,7 +43,7 @@ type
 proc createFixedPrefix*(value: int): SlicetransformRef =
   SlicetransformRef(cPtr: rocksdb_slicetransform_create_fixed_prefix(value.csize_t))
 
-proc isClosed*(s: SlicetransformRef): bool {.inline.} =
+template isClosed*(s: SlicetransformRef): bool =
   s.cPtr.isNil()
 
 proc cPtr*(s: SlicetransformRef): SlicetransformPtr =
@@ -58,7 +58,7 @@ proc close*(s: SlicetransformRef) =
 proc createColFamilyOptions*(autoClose = false): ColFamilyOptionsRef =
   ColFamilyOptionsRef(cPtr: rocksdb_options_create(), autoClose: autoClose)
 
-proc isClosed*(cfOpts: ColFamilyOptionsRef): bool {.inline.} =
+template isClosed*(cfOpts: ColFamilyOptionsRef): bool =
   cfOpts.cPtr.isNil()
 
 proc cPtr*(cfOpts: ColFamilyOptionsRef): ColFamilyOptionsPtr =

--- a/rocksdb/internal/cftable.nim
+++ b/rocksdb/internal/cftable.nim
@@ -27,10 +27,10 @@ proc newColFamilyTable*(
 
   ColFamilyTableRef(columnFamilies: cfTable)
 
-proc isClosed*(table: ColFamilyTableRef): bool {.inline.} =
+template isClosed*(table: ColFamilyTableRef): bool =
   table.columnFamilies.isNil()
 
-proc get*(table: ColFamilyTableRef, name: string): ColFamilyHandleRef {.inline.} =
+template get*(table: ColFamilyTableRef, name: string): ColFamilyHandleRef =
   table.columnFamilies.getOrDefault(name)
 
 proc close*(table: ColFamilyTableRef) =

--- a/rocksdb/optimistictxdb.nim
+++ b/rocksdb/optimistictxdb.nim
@@ -94,7 +94,7 @@ proc getColFamilyHandle*(
   else:
     ok(cfHandle)
 
-proc isClosed*(db: OptimisticTxDbRef): bool {.inline.} =
+template isClosed*(db: OptimisticTxDbRef): bool =
   ## Returns `true` if the `OptimisticTxDbRef` has been closed.
   db.cPtr.isNil()
 

--- a/rocksdb/options/backupopts.nim
+++ b/rocksdb/options/backupopts.nim
@@ -25,7 +25,7 @@ proc createBackupEngineOptions*(
     cPtr: rocksdb_backup_engine_options_create(backupDir.cstring), autoClose: autoClose
   )
 
-proc isClosed*(backupOpts: BackupEngineOptionsRef): bool {.inline.} =
+template isClosed*(backupOpts: BackupEngineOptionsRef): bool =
   backupOpts.cPtr.isNil()
 
 proc cPtr*(backupOpts: BackupEngineOptionsRef): BackupEngineOptionsPtr =
@@ -53,7 +53,7 @@ opt callbackTriggerIntervalSize, int, uint64
 
 proc defaultBackupEngineOptions*(
     backupDir: string, autoClose = false
-): BackupEngineOptionsRef {.inline.} =
+): BackupEngineOptionsRef =
   let backupOpts = createBackupEngineOptions(backupDir, autoClose)
 
   # TODO: set defaults here

--- a/rocksdb/options/dbopts.nim
+++ b/rocksdb/options/dbopts.nim
@@ -24,7 +24,7 @@ type
 proc createDbOptions*(autoClose = false): DbOptionsRef =
   DbOptionsRef(cPtr: rocksdb_options_create(), autoClose: autoClose)
 
-proc isClosed*(dbOpts: DbOptionsRef): bool {.inline.} =
+template isClosed*(dbOpts: DbOptionsRef): bool =
   dbOpts.cPtr.isNil()
 
 proc cPtr*(dbOpts: DbOptionsRef): DbOptionsPtr =

--- a/rocksdb/options/readopts.nim
+++ b/rocksdb/options/readopts.nim
@@ -23,7 +23,7 @@ type
 proc createReadOptions*(autoClose = false): ReadOptionsRef =
   ReadOptionsRef(cPtr: rocksdb_readoptions_create(), autoClose: autoClose)
 
-proc isClosed*(readOpts: ReadOptionsRef): bool {.inline.} =
+template isClosed*(readOpts: ReadOptionsRef): bool =
   readOpts.cPtr.isNil()
 
 proc cPtr*(readOpts: ReadOptionsRef): ReadOptionsPtr =
@@ -57,7 +57,7 @@ proc setSnapshot*(readOpts: ReadOptionsRef, snapshot: SnapshotRef) =
   doAssert not readOpts.isClosed()
   rocksdb_readoptions_set_snapshot(readOpts.cPtr, snapshot.cPtr)
 
-proc defaultReadOptions*(autoClose = false): ReadOptionsRef {.inline.} =
+proc defaultReadOptions*(autoClose = false): ReadOptionsRef =
   let readOpts = createReadOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/options/readopts.nim
+++ b/rocksdb/options/readopts.nim
@@ -52,6 +52,7 @@ opt maxSkippableInternalKeys, int, csize_t
 opt ignoreRangeDeletions, bool, uint8
 opt deadline, int, uint64
 opt ioTimeout, int, uint64
+opt asyncIo, bool, uint8
 
 proc setSnapshot*(readOpts: ReadOptionsRef, snapshot: SnapshotRef) =
   doAssert not readOpts.isClosed()

--- a/rocksdb/options/writeopts.nim
+++ b/rocksdb/options/writeopts.nim
@@ -21,7 +21,7 @@ type
 proc createWriteOptions*(autoClose = false): WriteOptionsRef =
   WriteOptionsRef(cPtr: rocksdb_writeoptions_create(), autoClose: autoClose)
 
-proc isClosed*(writeOpts: WriteOptionsRef): bool {.inline.} =
+template isClosed*(writeOpts: WriteOptionsRef): bool =
   writeOpts.cPtr.isNil()
 
 proc cPtr*(writeOpts: WriteOptionsRef): WriteOptionsPtr =
@@ -51,7 +51,7 @@ proc disableWAL*(writeOpts: WriteOptionsRef): bool =
   doAssert not writeOpts.isClosed()
   rocksdb_writeoptions_get_disable_WAL(writeOpts.cPtr).bool
 
-proc defaultWriteOptions*(autoClose = false): WriteOptionsRef {.inline.} =
+proc defaultWriteOptions*(autoClose = false): WriteOptionsRef =
   let writeOpts = createWriteOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -221,11 +221,11 @@ proc getColFamilyHandle*(
   else:
     ok(cfHandle)
 
-proc isClosed*(db: RocksDbRef): bool {.inline.} =
+template isClosed*(db: RocksDbRef): bool =
   ## Returns `true` if the database has been closed and `false` otherwise.
   db.cPtr.isNil()
 
-proc cPtr*(db: RocksDbRef): RocksDbPtr {.inline.} =
+proc cPtr*(db: RocksDbRef): RocksDbPtr =
   ## Get the underlying database pointer.
   doAssert not db.isClosed()
   db.cPtr

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -360,6 +360,28 @@ proc delete*(
 
   ok()
 
+proc deleteRange*(
+    db: RocksDbReadWriteRef, startKey, endKey: openArray[byte], cfHandle = db.defaultCfHandle
+): RocksDBResult[void] =
+  ## Removes the database entries in the range [startKey, endKey), i.e. including
+  ## startKey and excluding endKey. It is not an error if no keys exist in the
+  ## range ["beginKey", "endKey").
+
+  var errors: cstring
+  rocksdb_delete_range_cf(
+    db.cPtr,
+    db.writeOpts.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](startKey.unsafeAddrOrNil()),
+    csize_t(startKey.len),
+    cast[cstring](endKey.unsafeAddrOrNil()),
+    csize_t(endKey.len),
+    cast[cstringArray](errors.addr),
+  )
+  bailOnErrors(errors)
+
+  ok()
+
 proc openIterator*(
     db: RocksDbRef,
     readOpts = defaultReadOptions(autoClose = true),

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -313,7 +313,7 @@ proc multiGet*(
     when NimMajor >= 2 and NimMinor >= 2:
       newSeqUninit[ptr rocksdb_pinnableslice_t](keys.len)
     else:
-      newSeqUninitialized[ptr rocksdb_pinnableslice_t](keys.len)
+      newSeq[ptr rocksdb_pinnableslice_t](keys.len)
 
   rocksdb_batched_multi_get_cf(
     db.cPtr,
@@ -338,7 +338,7 @@ proc multiGet*(
         when NimMajor >= 2 and NimMinor >= 2:
           newSeqUninit[byte](vLen.int)
         else:
-          newSeqUninitialized[byte](vLen.int)
+          newSeq[byte](vLen.int)
 
       copyMem(dest[0].addr, src, vLen)
       data[i] = dest

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -384,6 +384,45 @@ proc deleteRange*(
 
   ok()
 
+proc compactRange*(
+    db: RocksDbReadWriteRef,
+    startKey, endKey: openArray[byte],
+    cfHandle = db.defaultCfHandle,
+): RocksDBResult[void] =
+  ## Trigger range compaction for the given key range.
+
+  rocksdb_compact_range_cf(
+    db.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](startKey.unsafeAddrOrNil()),
+    csize_t(startKey.len),
+    cast[cstring](endKey.unsafeAddrOrNil()),
+    csize_t(endKey.len)
+  )
+
+  ok()
+
+proc suggestCompactRange*(
+    db: RocksDbReadWriteRef,
+    startKey, endKey: openArray[byte],
+    cfHandle = db.defaultCfHandle,
+): RocksDBResult[void] =
+  ## Suggest the range to compact.
+
+  var errors: cstring
+  rocksdb_suggest_compact_range_cf(
+    db.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](startKey.unsafeAddrOrNil()),
+    csize_t(startKey.len),
+    cast[cstring](endKey.unsafeAddrOrNil()),
+    csize_t(endKey.len),
+    cast[cstringArray](errors.addr),
+  )
+  bailOnErrors(errors)
+
+  ok()
+
 proc openIterator*(
     db: RocksDbRef,
     readOpts = defaultReadOptions(autoClose = true),

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -361,7 +361,9 @@ proc delete*(
   ok()
 
 proc deleteRange*(
-    db: RocksDbReadWriteRef, startKey, endKey: openArray[byte], cfHandle = db.defaultCfHandle
+    db: RocksDbReadWriteRef,
+    startKey, endKey: openArray[byte],
+    cfHandle = db.defaultCfHandle,
 ): RocksDBResult[void] =
   ## Removes the database entries in the range [startKey, endKey), i.e. including
   ## startKey and excluding endKey. It is not an error if no keys exist in the

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -29,7 +29,7 @@ proc newRocksIterator*(
   doAssert not cPtr.isNil()
   RocksIteratorRef(cPtr: cPtr, readOpts: readOpts)
 
-proc isClosed*(iter: RocksIteratorRef): bool {.inline.} =
+template isClosed*(iter: RocksIteratorRef): bool =
   ## Returns `true` if the iterator is closed and `false` otherwise.
   iter.cPtr.isNil()
 

--- a/rocksdb/rocksresult.nim
+++ b/rocksdb/rocksresult.nim
@@ -17,5 +17,3 @@ type
   RocksDBResult*[T] = Result[T, string]
 
   DataProc* = proc(val: openArray[byte]) {.gcsafe, raises: [].}
-
-  DataBatchProc* = proc(val: openArray[seq[byte]]) {.gcsafe, raises: [].}

--- a/rocksdb/rocksresult.nim
+++ b/rocksdb/rocksresult.nim
@@ -17,3 +17,5 @@ type
   RocksDBResult*[T] = Result[T, string]
 
   DataProc* = proc(val: openArray[byte]) {.gcsafe, raises: [].}
+
+  DataBatchProc* = proc(val: openArray[seq[byte]]) {.gcsafe, raises: [].}

--- a/rocksdb/snapshot.nim
+++ b/rocksdb/snapshot.nim
@@ -28,7 +28,7 @@ proc newSnapshot*(cPtr: SnapshotPtr, kind: SnapshotType): SnapshotRef =
   doAssert not cPtr.isNil()
   SnapshotRef(cPtr: cPtr, kind: kind)
 
-proc isClosed*(snapshot: SnapshotRef): bool {.inline.} =
+template isClosed*(snapshot: SnapshotRef): bool =
   ## Returns `true` if the `SnapshotRef` has been closed and `false` otherwise.
   snapshot.cPtr.isNil()
 

--- a/rocksdb/sstfilewriter.nim
+++ b/rocksdb/sstfilewriter.nim
@@ -49,7 +49,7 @@ proc openSstFileWriter*(
 
   ok(writer)
 
-proc isClosed*(writer: SstFileWriterRef): bool {.inline.} =
+template isClosed*(writer: SstFileWriterRef): bool =
   ## Returns `true` if the `SstFileWriterRef` is closed and `false` otherwise.
   writer.cPtr.isNil()
 

--- a/rocksdb/transactiondb.nim
+++ b/rocksdb/transactiondb.nim
@@ -102,7 +102,7 @@ proc getColFamilyHandle*(
   else:
     ok(cfHandle)
 
-proc isClosed*(db: TransactionDbRef): bool {.inline.} =
+template isClosed*(db: TransactionDbRef): bool =
   ## Returns `true` if the `TransactionDbRef` has been closed.
   db.cPtr.isNil()
 

--- a/rocksdb/transactions/otxopts.nim
+++ b/rocksdb/transactions/otxopts.nim
@@ -23,7 +23,7 @@ proc createOptimisticTxOptions*(autoClose = false): OptimisticTxOptionsRef =
     cPtr: rocksdb_optimistictransaction_options_create(), autoClose: autoClose
   )
 
-proc isClosed*(txOpts: OptimisticTxOptionsRef): bool {.inline.} =
+template isClosed*(txOpts: OptimisticTxOptionsRef): bool =
   txOpts.cPtr.isNil()
 
 proc cPtr*(txOpts: OptimisticTxOptionsRef): OptimisticTxOptionsPtr =
@@ -37,7 +37,7 @@ template setOpt(nname, ntyp, ctyp: untyped) =
 
 setOpt setSnapshot, bool, uint8
 
-proc defaultOptimisticTxOptions*(autoClose = false): OptimisticTxOptionsRef {.inline.} =
+proc defaultOptimisticTxOptions*(autoClose = false): OptimisticTxOptionsRef =
   let txOpts = createOptimisticTxOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/transactions/transaction.nim
+++ b/rocksdb/transactions/transaction.nim
@@ -56,7 +56,7 @@ proc newTransaction*(
     defaultCfHandle: defaultCfHandle,
   )
 
-proc isClosed*(tx: TransactionRef): bool {.inline.} =
+template isClosed*(tx: TransactionRef): bool =
   ## Returns `true` if the `TransactionRef` has been closed.
   tx.cPtr.isNil()
 

--- a/rocksdb/transactions/txdbopts.nim
+++ b/rocksdb/transactions/txdbopts.nim
@@ -23,7 +23,7 @@ proc createTransactionDbOptions*(autoClose = false): TransactionDbOptionsRef =
     cPtr: rocksdb_transactiondb_options_create(), autoClose: autoClose
   )
 
-proc isClosed*(txDbOpts: TransactionDbOptionsRef): bool {.inline.} =
+template isClosed*(txDbOpts: TransactionDbOptionsRef): bool =
   txDbOpts.cPtr.isNil()
 
 proc cPtr*(txDbOpts: TransactionDbOptionsRef): TransactionDbOptionsPtr =
@@ -42,7 +42,7 @@ setOpt defaultLockTimeout, int, int64
 
 proc defaultTransactionDbOptions*(
     autoClose = false
-): TransactionDbOptionsRef {.inline.} =
+): TransactionDbOptionsRef =
   let txDbOpts = createTransactionDbOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/transactions/txdbopts.nim
+++ b/rocksdb/transactions/txdbopts.nim
@@ -40,9 +40,7 @@ setOpt numStripes, int, csize_t
 setOpt transactionLockTimeout, int, int64
 setOpt defaultLockTimeout, int, int64
 
-proc defaultTransactionDbOptions*(
-    autoClose = false
-): TransactionDbOptionsRef =
+proc defaultTransactionDbOptions*(autoClose = false): TransactionDbOptionsRef =
   let txDbOpts = createTransactionDbOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/transactions/txopts.nim
+++ b/rocksdb/transactions/txopts.nim
@@ -23,7 +23,7 @@ proc createTransactionOptions*(autoClose = false): TransactionOptionsRef =
     cPtr: rocksdb_transaction_options_create(), autoClose: autoClose
   )
 
-proc isClosed*(txOpts: TransactionOptionsRef): bool {.inline.} =
+template isClosed*(txOpts: TransactionOptionsRef): bool =
   txOpts.cPtr.isNil()
 
 proc cPtr*(txOpts: TransactionOptionsRef): TransactionOptionsPtr =
@@ -42,7 +42,7 @@ setOpt deadlockDetectDepth, int, int64
 setOpt maxWriteBatchSize, int, csize_t
 setOpt skipPrepare, bool, uint8
 
-proc defaultTransactionOptions*(autoClose = false): TransactionOptionsRef {.inline.} =
+proc defaultTransactionOptions*(autoClose = false): TransactionOptionsRef =
   let txOpts = createTransactionOptions(autoClose)
 
   # TODO: set prefered defaults

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -68,10 +68,7 @@ proc delete*(
   ## Add a delete operation to the write batch.
 
   rocksdb_writebatch_delete_cf(
-    batch.cPtr,
-    cfHandle.cPtr,
-    cast[cstring](key.unsafeAddrOrNil()),
-    csize_t(key.len)
+    batch.cPtr, cfHandle.cPtr, cast[cstring](key.unsafeAddrOrNil()), csize_t(key.len)
   )
 
   ok()
@@ -79,7 +76,7 @@ proc delete*(
 proc deleteRange*(
     batch: WriteBatchRef,
     startKey, endKey: openArray[byte],
-    cfHandle = batch.defaultCfHandle
+    cfHandle = batch.defaultCfHandle,
 ): RocksDBResult[void] =
   ## Add a delete range operation to the write batch.
 
@@ -89,7 +86,7 @@ proc deleteRange*(
     cast[cstring](startKey.unsafeAddrOrNil()),
     csize_t(startKey.len),
     cast[cstring](endKey.unsafeAddrOrNil()),
-    csize_t(endKey.len)
+    csize_t(endKey.len),
   )
 
   ok()

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -27,7 +27,7 @@ type
 proc createWriteBatch*(defaultCfHandle: ColFamilyHandleRef): WriteBatchRef =
   WriteBatchRef(cPtr: rocksdb_writebatch_create(), defaultCfHandle: defaultCfHandle)
 
-proc isClosed*(batch: WriteBatchRef): bool {.inline.} =
+template isClosed*(batch: WriteBatchRef): bool =
   ## Returns `true` if the `WriteBatchRef` has been closed and `false` otherwise.
   batch.cPtr.isNil()
 

--- a/rocksdb/writebatch.nim
+++ b/rocksdb/writebatch.nim
@@ -68,7 +68,28 @@ proc delete*(
   ## Add a delete operation to the write batch.
 
   rocksdb_writebatch_delete_cf(
-    batch.cPtr, cfHandle.cPtr, cast[cstring](key.unsafeAddrOrNil()), csize_t(key.len)
+    batch.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](key.unsafeAddrOrNil()),
+    csize_t(key.len)
+  )
+
+  ok()
+
+proc deleteRange*(
+    batch: WriteBatchRef,
+    startKey, endKey: openArray[byte],
+    cfHandle = batch.defaultCfHandle
+): RocksDBResult[void] =
+  ## Add a delete range operation to the write batch.
+
+  rocksdb_writebatch_delete_range_cf(
+    batch.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](startKey.unsafeAddrOrNil()),
+    csize_t(startKey.len),
+    cast[cstring](endKey.unsafeAddrOrNil()),
+    csize_t(endKey.len)
   )
 
   ok()

--- a/rocksdb/writebatchwi.nim
+++ b/rocksdb/writebatchwi.nim
@@ -41,7 +41,7 @@ proc createWriteBatch*(
     defaultCfHandle: defaultCfHandle,
   )
 
-proc isClosed*(batch: WriteBatchWIRef): bool {.inline.} =
+template isClosed*(batch: WriteBatchWIRef): bool =
   ## Returns `true` if the `WriteBatchWIRef` has been closed and `false` otherwise.
   batch.cPtr.isNil()
 

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -125,3 +125,29 @@ suite "ColFamily Tests":
       cf.keyExists(keyValue1).get() == false
       cf.keyExists(keyValue2).get() == false
       cf.keyExists(keyValue3).get() == true
+
+  test "Test multiget":
+    let cf = db.getColFamily(CF_OTHER).get()
+
+    let
+      keyValue1 = @[100.byte]
+      keyValue2 = @[300.byte]
+      keyValue3 = @[200.byte]
+
+    check:
+      cf.put(keyValue1, keyValue1).isOk()
+      cf.put(keyValue2, keyValue2).isOk()
+      cf.keyExists(keyValue1).get() == true
+      cf.keyExists(keyValue2).get() == true
+      cf.keyExists(keyValue3).get() == false
+
+    var dataRes: seq[seq[byte]]
+    proc onData(data: openArray[seq[byte]]) =
+      dataRes = @data
+
+    check:
+      cf.multiGet(@[keyValue1, keyValue2, keyValue3], onData).isOk()
+      dataRes.len() == 3
+      dataRes[0] == keyValue1
+      dataRes[1] == keyValue2
+      dataRes[2] == default(seq[byte])

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -101,3 +101,25 @@ suite "ColFamily Tests":
       iter.value() == val
     iter.seekToKey(otherKey)
     check iter.isValid() == false
+
+  test "Test deleteRange":
+    let cf = db.getColFamily(CF_OTHER).get()
+
+    let
+      keyValue1 = @[1.byte]
+      keyValue2 = @[2.byte]
+      keyValue3 = @[3.byte]
+
+    check:
+      cf.put(keyValue1, keyValue1).isOk()
+      cf.put(keyValue2, keyValue2).isOk()
+      cf.put(keyValue3, keyValue3).isOk()
+      cf.keyExists(keyValue1).get() == true
+      cf.keyExists(keyValue2).get() == true
+      cf.keyExists(keyValue3).get() == true
+
+      cf.deleteRange(keyValue1, keyValue3).isOk()
+
+      cf.keyExists(keyValue1).get() == false
+      cf.keyExists(keyValue2).get() == false
+      cf.keyExists(keyValue3).get() == true

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -118,7 +118,9 @@ suite "ColFamily Tests":
       cf.keyExists(keyValue2).get() == true
       cf.keyExists(keyValue3).get() == true
 
+      cf.suggestCompactRange(keyValue1, keyValue3).isOk()
       cf.deleteRange(keyValue1, keyValue3).isOk()
+      cf.compactRange(keyValue1, keyValue3).isOk()
 
       cf.keyExists(keyValue1).get() == false
       cf.keyExists(keyValue2).get() == false

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -141,12 +141,8 @@ suite "ColFamily Tests":
       cf.keyExists(keyValue2).get() == true
       cf.keyExists(keyValue3).get() == false
 
-    var dataRes: seq[seq[byte]]
-    proc onData(data: openArray[seq[byte]]) =
-      dataRes = @data
-
+    let dataRes = cf.multiGet(@[keyValue1, keyValue2, keyValue3]).expect("ok")
     check:
-      cf.multiGet(@[keyValue1, keyValue2, keyValue3], onData).isOk()
       dataRes.len() == 3
       dataRes[0] == keyValue1
       dataRes[1] == keyValue2

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -555,41 +555,76 @@ suite "RocksDbRef Tests":
       keyValue1 = @[1.byte]
       keyValue2 = @[2.byte]
       keyValue3 = @[3.byte]
+      keyValue4 = @[4.byte]
+      keyValue5 = @[5.byte]
+      keyValue6 = @[6.byte]
+      keyValue7 = @[7.byte]
+      keyValue8 = @[8.byte]
+      keyValue9 = @[9.byte]
 
     check:
       db.put(keyValue1, keyValue1).isOk()
       db.put(keyValue2, keyValue2).isOk()
+      db.put(keyValue5, keyValue5).isOk()
+      db.put(keyValue7, keyValue7).isOk()
+      db.put(keyValue9, keyValue9).isOk()
       db.keyExists(keyValue1).get() == true
       db.keyExists(keyValue2).get() == true
       db.keyExists(keyValue3).get() == false
 
-    var dataRes: seq[seq[byte]]
-    proc onData(data: openArray[seq[byte]]) =
-      dataRes = @data
+    block:
+      let dataRes = db.multiGet(@[keyValue1]).expect("ok")
+      check:
+        dataRes.len() == 1
+        dataRes[0] == keyValue1
 
-    check:
-      db.multiGet(@[keyValue1], onData).isOk()
-      dataRes.len() == 1
-      dataRes[0] == keyValue1
+    block:
+      let dataRes = db.multiGet(@[keyValue1, keyValue2]).expect("ok")
+      check:
+        dataRes.len() == 2
+        dataRes[0] == keyValue1
+        dataRes[1] == keyValue2
 
-      db.multiGet(@[keyValue1, keyValue2], onData).isOk()
-      dataRes.len() == 2
-      dataRes[0] == keyValue1
-      dataRes[1] == keyValue2
+    block:
+      let dataRes = db.multiGet(@[keyValue2, keyValue3]).expect("ok")
+      check:
+        dataRes.len() == 2
+        dataRes[0] == keyValue2
+        dataRes[1] == default(seq[byte])
 
-      db.multiGet(@[keyValue2, keyValue3], onData).isOk()
-      dataRes.len() == 2
-      dataRes[0] == keyValue2
-      dataRes[1] == default(seq[byte])
+    block:
+      let dataRes = db.multiGet(@[keyValue1, keyValue2, keyValue3]).expect("ok")
+      check:
+        dataRes.len() == 3
+        dataRes[0] == keyValue1
+        dataRes[1] == keyValue2
+        dataRes[2] == default(seq[byte])
 
-      db.multiGet(@[keyValue1, keyValue2, keyValue3], onData).isOk()
-      dataRes.len() == 3
-      dataRes[0] == keyValue1
-      dataRes[1] == keyValue2
-      dataRes[2] == default(seq[byte])
+    block:
+      let dataRes =
+        db.multiGet(@[keyValue1, keyValue2, keyValue3], sortedInput = true).expect("ok")
+      check:
+        dataRes.len() == 3
+        dataRes[0] == keyValue1
+        dataRes[1] == keyValue2
+        dataRes[2] == default(seq[byte])
 
-      db.multiGet(@[keyValue1, keyValue2, keyValue3], onData, sortedInput = true).isOk()
-      dataRes.len() == 3
-      dataRes[0] == keyValue1
-      dataRes[1] == keyValue2
-      dataRes[2] == default(seq[byte])
+    block:
+      let
+        keys =
+          @[
+            keyValue1, keyValue2, keyValue3, keyValue4, keyValue5, keyValue6, keyValue7,
+            keyValue8, keyValue9,
+          ]
+        dataRes = db.multiGet(keys).expect("ok")
+      check:
+        dataRes.len() == 9
+        dataRes[0] == keyValue1
+        dataRes[1] == keyValue2
+        dataRes[2] == default(seq[byte])
+        dataRes[3] == default(seq[byte])
+        dataRes[4] == keyValue5
+        dataRes[5] == default(seq[byte])
+        dataRes[6] == keyValue7
+        dataRes[7] == default(seq[byte])
+        dataRes[8] == keyValue9

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -514,3 +514,36 @@ suite "RocksDbRef Tests":
       db.put(otherKey, val, defaultCfHandle).isOk()
       db.put(key, val, otherCfHandle).isOk()
       db.flush(cfHandles).isOk()
+
+  test "Test deleteRange":
+    let
+      keyValue1 = @[1.byte]
+      keyValue2 = @[2.byte]
+      keyValue3 = @[3.byte]
+
+    check:
+      db.put(keyValue1, keyValue1).isOk()
+      db.put(keyValue2, keyValue2).isOk()
+      db.put(keyValue3, keyValue3).isOk()
+      db.keyExists(keyValue1).get() == true
+      db.keyExists(keyValue2).get() == true
+      db.keyExists(keyValue3).get() == true
+
+      db.deleteRange(keyValue1, keyValue3).isOk()
+
+      db.keyExists(keyValue1).get() == false
+      db.keyExists(keyValue2).get() == false
+      db.keyExists(keyValue3).get() == true
+
+    check:
+      db.put(keyValue1, keyValue1, otherCfHandle).isOk()
+      db.put(keyValue2, keyValue2, otherCfHandle).isOk()
+      db.keyExists(keyValue1, otherCfHandle).get() == true
+      db.keyExists(keyValue2, otherCfHandle).get() == true
+      db.keyExists(keyValue3, otherCfHandle).get() == false
+
+      db.deleteRange(keyValue1, keyValue2, otherCfHandle).isOk()
+
+      db.keyExists(keyValue1, otherCfHandle).get() == false
+      db.keyExists(keyValue2, otherCfHandle).get() == true
+      db.keyExists(keyValue3, otherCfHandle).get() == false

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -530,6 +530,7 @@ suite "RocksDbRef Tests":
       db.keyExists(keyValue3).get() == true
 
       db.deleteRange(keyValue1, keyValue3).isOk()
+      db.compactRange(keyValue1, keyValue3).isOk()
 
       db.keyExists(keyValue1).get() == false
       db.keyExists(keyValue2).get() == false
@@ -543,6 +544,7 @@ suite "RocksDbRef Tests":
       db.keyExists(keyValue3, otherCfHandle).get() == false
 
       db.deleteRange(keyValue1, keyValue2, otherCfHandle).isOk()
+      db.suggestCompactRange(keyValue1, keyValue3, otherCfHandle).isOk()
 
       db.keyExists(keyValue1, otherCfHandle).get() == false
       db.keyExists(keyValue2, otherCfHandle).get() == true

--- a/tests/test_writebatch.nim
+++ b/tests/test_writebatch.nim
@@ -195,3 +195,27 @@ suite "WriteBatchRef Tests":
     check batch.isClosed()
     batch.close()
     check batch.isClosed()
+
+  test "Test deleteRange":
+    let batch = db.openWriteBatch()
+    defer:
+      batch.close()
+
+    let
+      keyValue1 = @[1.byte]
+      keyValue2 = @[2.byte]
+      keyValue3 = @[3.byte]
+
+    check:
+      batch.put(keyValue1, keyValue1).isOk()
+      batch.put(keyValue2, keyValue2).isOk()
+      batch.put(keyValue3, keyValue3).isOk()
+      batch.deleteRange(keyValue1, keyValue3).isOk()
+      batch.count() == 4
+
+    let res1 = db.write(batch)
+    check:
+      res1.isOk()
+      db.keyExists(keyValue1).get() == false
+      db.keyExists(keyValue2).get() == false
+      db.keyExists(keyValue3).get() == true


### PR DESCRIPTION
This PR adds the following features to the RocksDbReadWriteRef and ColFamilyReadWrite types:
- `deleteRange` to support bulk deleting records within the given key range.
- `compactRange` and `suggestCompactRange` to either force compaction or just suggest that the range should be compacted.
- `multiGet` to support bulk fetching of data. The multiGet API improves performance by batching operations in the read path for greater efficiency. This operation may perform better than using individual key look ups when using the block based table format with full filters.