### PR TITLE
Add multiGetIter function returning iterator handle and iterators which yield slices

### DIFF
--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -78,6 +78,14 @@ template get*(
   ## Gets the value of the given key from the column family.
   cf.db.get(key, cf.handle)
 
+template multiGetIter*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    keys: openArray[seq[byte]],
+    sortedInput = false,
+): RocksDBResult[MultiGetIteratorRef] =
+  ## Get a batch of values for the given set of keys.
+  cf.db.multiGetIter(keys, sortedInput, cf.handle)
+
 template multiGet*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     keys: openArray[seq[byte]],

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -133,7 +133,9 @@ proc close*(iter: RocksIteratorRef) =
 
     autoCloseNonNil(iter.readOpts)
 
-iterator pairs*(iter: RocksIteratorRef, autoClose: static bool = true): tuple[key: seq[byte], value: seq[byte]] =
+iterator pairs*(
+    iter: RocksIteratorRef, autoClose: static bool = true
+): tuple[key: seq[byte], value: seq[byte]] =
   ## Iterates over the key value pairs in the column family yielding them in
   ## the form of a tuple. The iterator is automatically closed after the
   ## iteration.
@@ -161,7 +163,9 @@ func value(iter: RocksIteratorRef, T: type RocksDbSlice): RocksDbSlice =
   let data = rocksdb_iter_value(iter.cPtr, len.addr)
   RocksDbSlice.init(data, len)
 
-iterator pairs*(iter: RocksIteratorRef, T: type RocksDbSlice, autoClose: static bool = true): tuple[key: T, value: T] =
+iterator pairs*(
+    iter: RocksIteratorRef, T: type RocksDbSlice, autoClose: static bool = true
+): tuple[key: T, value: T] =
   ## Iterates over the key value pairs in the column family yielding them in
   ## the form of a tuple. The iterator is automatically closed after the
   ## iteration.

--- a/rocksdb/rocksslice.nim
+++ b/rocksdb/rocksslice.nim
@@ -1,0 +1,35 @@
+# Nim-RocksDB
+# Copyright 2025 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+## A `RocksIteratorRef` is a reference to a RocksDB iterator which supports
+## iterating over the key value pairs in a column family.
+
+{.push raises: [].}
+
+type
+  RocksDbSlice* = object
+    data: cstring
+    len: csize_t
+
+template init*(T: type RocksDbSlice, data: cstring, len: csize_t) =
+  RocksDbSlice(data: data, len: len)
+
+template dataOpenArray(slice: RocksDbSlice): openArray[byte] =
+  const empty = []
+  if slice.data.isNil or slice.len == 0:
+    empty.toOpenArrayByte(0, -1)
+  else:
+    slice.data.toOpenArrayByte(0, slice.len.int - 1)
+
+template data*(slice: RocksDbSlice, asOpenArray: static bool = false): auto =
+  ## Returns the data.
+  when asOpenArray:
+    iter.keyOpenArray()
+  else:
+    @(iter.keyOpenArray())

--- a/rocksdb/rocksslice.nim
+++ b/rocksdb/rocksslice.nim
@@ -16,19 +16,22 @@ type RocksDbSlice* = object
   data: cstring
   len: csize_t
 
-template init*(T: type RocksDbSlice, data: cstring, len: csize_t) =
-  RocksDbSlice(data: data, len: len)
+func init*(T: type RocksDbSlice, data: cstring, len: csize_t): T =
+  T(data: data, len: len)
 
-template dataOpenArray(slice: RocksDbSlice): openArray[byte] =
+template toOpenArray*(data: cstring, len: csize_t): openArray[byte] =
   const empty = []
-  if slice.data.isNil or slice.len == 0:
+  if data.isNil or len == 0:
     empty.toOpenArrayByte(0, -1)
   else:
-    slice.data.toOpenArrayByte(0, slice.len.int - 1)
+    data.toOpenArrayByte(0, len.int - 1)
+
+template toOpenArray*(slice: RocksDbSlice): openArray[byte] =
+  toOpenArray(slice.data, slice.len)
 
 template data*(slice: RocksDbSlice, asOpenArray: static bool = false): auto =
   ## Returns the data.
   when asOpenArray:
-    iter.keyOpenArray()
+    slice.toOpenArray()
   else:
-    @(iter.keyOpenArray())
+    @(slice.toOpenArray())

--- a/rocksdb/rocksslice.nim
+++ b/rocksdb/rocksslice.nim
@@ -12,10 +12,9 @@
 
 {.push raises: [].}
 
-type
-  RocksDbSlice* = object
-    data: cstring
-    len: csize_t
+type RocksDbSlice* = object
+  data: cstring
+  len: csize_t
 
 template init*(T: type RocksDbSlice, data: cstring, len: csize_t) =
   RocksDbSlice(data: data, len: len)

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -179,6 +179,21 @@ suite "RocksIteratorRef Tests":
       iter.key() == empty
       iter.value() == val1
 
+  test "Empty value":
+    let key = @[0x1.byte, 0x2, 0x3]
+    let empty: seq[byte] = @[]
+    check db.put(key, empty).isOk()
+
+    let iter = db.openIterator().get()
+    defer:
+      iter.close()
+
+    iter.seekToKey(key)
+    check:
+      iter.isValid()
+      iter.key() == key
+      iter.value() == empty
+
   test "Empty column family":
     let res = db.openIterator(cfHandle = emptyCfHandle)
     check res.isOk()

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -237,10 +237,12 @@ suite "RocksIteratorRef Tests":
     var iter = res.get()
 
     var expected = byte(1)
-    for k, v in iter.pairs(RocksDbSlice):
+    for k, v in iter.slicePairs():
       check:
         k.data() == @[expected]
         v.data() == @[expected]
+        k.data(asOpenArray = true) == [expected]
+        v.data(asOpenArray = true) == @[expected]
       inc expected
     check iter.isClosed()
 

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -223,28 +223,50 @@ suite "RocksIteratorRef Tests":
     check res.isOk()
     var iter = res.get()
 
-    var expected = byte(1)
-    for k, v in iter:
-      check:
-        k == @[expected]
-        v == @[expected]
-      inc expected
-    check iter.isClosed()
+    block:
+      var expected = byte(1)
+      for k, v in iter.pairs(autoClose = false):
+        check:
+          k == @[expected]
+          v == @[expected]
+        inc expected
+      check not iter.isClosed()
+
+    block:
+      var expected = byte(1)
+      for k, v in iter:
+        check:
+          k == @[expected]
+          v == @[expected]
+        inc expected
+      check iter.isClosed()
 
   test "Test pairs slice iterator":
     let res = db.openIterator(cfHandle = defaultCfHandle)
     check res.isOk()
     var iter = res.get()
 
-    var expected = byte(1)
-    for k, v in iter.slicePairs():
-      check:
-        k.data() == @[expected]
-        v.data() == @[expected]
-        k.data(asOpenArray = true) == [expected]
-        v.data(asOpenArray = true) == @[expected]
-      inc expected
-    check iter.isClosed()
+    block:
+      var expected = byte(1)
+      for k, v in iter.slicePairs(autoClose = false):
+        check:
+          k.data() == @[expected]
+          v.data() == @[expected]
+          k.data(asOpenArray = true) == [expected]
+          v.data(asOpenArray = true) == @[expected]
+        inc expected
+      check not iter.isClosed()
+
+    block:
+      var expected = byte(1)
+      for k, v in iter.slicePairs():
+        check:
+          k.data() == @[expected]
+          v.data() == @[expected]
+          k.data(asOpenArray = true) == [expected]
+          v.data(asOpenArray = true) == @[expected]
+        inc expected
+      check iter.isClosed()
 
   test "Test close":
     let res = db.openIterator()

--- a/tests/test_rocksiterator.nim
+++ b/tests/test_rocksiterator.nim
@@ -1,5 +1,5 @@
 # Nim-RocksDB
-# Copyright 2024 Status Research & Development GmbH
+# Copyright 2024-2025 Status Research & Development GmbH
 # Licensed under either of
 #
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -228,6 +228,19 @@ suite "RocksIteratorRef Tests":
       check:
         k == @[expected]
         v == @[expected]
+      inc expected
+    check iter.isClosed()
+
+  test "Test pairs slice iterator":
+    let res = db.openIterator(cfHandle = defaultCfHandle)
+    check res.isOk()
+    var iter = res.get()
+
+    var expected = byte(1)
+    for k, v in iter.pairs(RocksDbSlice):
+      check:
+        k.data() == @[expected]
+        v.data() == @[expected]
       inc expected
     check iter.isClosed()
 


### PR DESCRIPTION
This PR adds the following:
- `RocksDbSlice` type created which holds a pointer to some allocated data and a len. Supports returning the data either as a `seq[byte]` or an `openArray[byte]` by calling the data() template.
- Implemented `MultiGetIteratorRef` type which is returned from the `multiGetIter` function. Is basically a handle to the data to be iterated on.
- Added a new `multiGetIter` function to both the `RocksDb` and `ColumnFamily` types which returns the `MultiGetIteratorRef` type instead of the `seq[Opt[seq[byte]]]`
- Added `slicePairs` function to the `RocksIteratorRef` type which supports returning the data using the new `RocksDbSlice` type.