### PR TITLE
Use new RocksDB high-performance get functions

### DIFF
--- a/rocksdb/columnfamily.nim
+++ b/rocksdb/columnfamily.nim
@@ -78,6 +78,16 @@ template get*(
   ## Gets the value of the given key from the column family.
   cf.db.get(key, cf.handle)
 
+template get*(
+    cf: ColFamilyReadOnly | ColFamilyReadWrite,
+    key: openArray[byte],
+    data: var openArray[byte],
+    dataLen: var int,
+): RocksDBResult[bool] =
+  ## Gets the value of the given key from the column family into the
+  ## caller-provided buffer `data` and sets `dataLen` to the valid length.
+  cf.db.get(key, data, dataLen, cf.handle)
+
 template multiGetIter*(
     cf: ColFamilyReadOnly | ColFamilyReadWrite,
     keys: openArray[seq[byte]],

--- a/rocksdb/lib/rocksdb_gen.nim
+++ b/rocksdb/lib/rocksdb_gen.nim
@@ -47,7 +47,7 @@
 ##  This struct is ABI-compatible with rocksdb::Slice for zero-copy interop.
 ##  Used by slice iterator functions and batched operations.
 
-type rocksdb_slice_t* {.bycopy.} = object
+type rocksdb_slice_t* = object
   data*: cstring
   size*: csize_t
 

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -281,6 +281,50 @@ proc get*(
   else:
     err("rocksdb: value does not exist")
 
+proc get*(
+    db: RocksDbRef,
+    key: openArray[byte],
+    data: var openArray[byte],
+    dataLen: var int,
+    cfHandle = db.defaultCfHandle,
+): RocksDBResult[bool] =
+  ## Get the value for the given key from the specified column family into the
+  ## caller-provided buffer `data`. If the key does not exist, `false` will be
+  ## returned in the result, `dataLen` will be set to `0`, and `data` will not
+  ## be modified. If the key exists and the value fits in the buffer, `true`
+  ## will be returned, `dataLen` will be set to the number of bytes written,
+  ## and the value bytes will have been written into `data[0..<dataLen]`. If
+  ## the buffer is too small to hold the value, an error will be returned and
+  ## `dataLen` will be set to the required length.
+
+  var
+    vallen: csize_t
+    found: uint8
+    errors: cstring
+  let fits = rocksdb_get_into_buffer_cf(
+    db.cPtr,
+    db.readOpts.cPtr,
+    cfHandle.cPtr,
+    cast[cstring](key.unsafeAddrOrNil()),
+    csize_t(key.len),
+    cast[cstring](data.unsafeAddrOrNil()),
+    csize_t(data.len),
+    vallen.addr,
+    found.addr,
+    cast[cstringArray](errors.addr),
+  )
+  bailOnErrors(errors)
+
+  dataLen = vallen.int
+
+  if found == 0:
+    dataLen = 0
+    ok(false)
+  elif fits == 0:
+    err("rocksdb: buffer too small, value length is " & $vallen)
+  else:
+    ok(true)
+
 proc multiGetIter*(
     db: RocksDbRef,
     keys: openArray[seq[byte]],

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -304,19 +304,17 @@ proc multiGetIter*(
   assert keys.len() > 0
 
   var
-    keysList = keys.mapIt(cast[cstring](it.unsafeAddrOrNil()))
-    keysListSizes = keys.mapIt(csize_t(it.len))
+    keySlices = keys.mapIt(rocksdb_slice_t(data: cast[cstring](it.unsafeAddrOrNil()), size: csize_t(it.len)))
     errors = newSeq[cstring](keys.len())
 
   let multiGetIter = MultiGetIteratorRef.init(keys.len)
 
-  rocksdb_batched_multi_get_cf(
+  rocksdb_batched_multi_get_cf_slice(
     db.cPtr,
     db.readOpts.cPtr,
     cfHandle.cPtr,
     csize_t(keys.len),
-    cast[cstringArray](keysList[0].addr),
-    keysListSizes[0].addr,
+    keySlices[0].addr,
     multiGetIter[][0].addr,
     cast[cstringArray](errors[0].addr),
     sortedInput,

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -304,7 +304,9 @@ proc multiGetIter*(
   assert keys.len() > 0
 
   var
-    keySlices = keys.mapIt(rocksdb_slice_t(data: cast[cstring](it.unsafeAddrOrNil()), size: csize_t(it.len)))
+    keySlices = keys.mapIt(
+      rocksdb_slice_t(data: cast[cstring](it.unsafeAddrOrNil()), size: csize_t(it.len))
+    )
     errors = newSeq[cstring](keys.len())
 
   let multiGetIter = MultiGetIteratorRef.init(keys.len)

--- a/rocksdb/rocksdb.nim
+++ b/rocksdb/rocksdb.nim
@@ -243,26 +243,25 @@ proc get*(
   ## The `onData` callback reduces the number of copies and therefore should be
   ## preferred if performance is required.
 
-  var
-    len: csize_t
-    errors: cstring
-  let data = rocksdb_get_cf(
+  var errors: cstring
+  let handle = rocksdb_get_pinned_cf_v2(
     db.cPtr,
     db.readOpts.cPtr,
     cfHandle.cPtr,
     cast[cstring](key.unsafeAddrOrNil()),
     csize_t(key.len),
-    len.addr,
     cast[cstringArray](errors.addr),
   )
   bailOnErrors(errors)
 
-  if data.isNil():
-    doAssert len == 0
+  if handle.isNil():
     ok(false)
   else:
+    defer:
+      rocksdb_pinnable_handle_destroy(handle)
+    var len: csize_t
+    let data = rocksdb_pinnable_handle_get_value(handle, len.addr)
     onData(toOpenArrayByte(data, 0, len.int - 1))
-    rocksdb_free(data)
     ok(true)
 
 proc get*(

--- a/rocksdb/rocksiterator.nim
+++ b/rocksdb/rocksiterator.nim
@@ -117,9 +117,8 @@ proc prev*(iter: RocksIteratorRef) =
   rocksdb_iter_prev(iter.cPtr)
 
 template keyOpenArray(iter: RocksIteratorRef): openArray[byte] =
-  var kLen: csize_t
-  let kData = rocksdb_iter_key(iter.cPtr, kLen.addr)
-  toOpenArray(kData, kLen)
+  let kSlice = rocksdb_iter_key_slice(iter.cPtr)
+  toOpenArray(kSlice.data, kSlice.size)
 
 proc key*(iter: RocksIteratorRef, onData: DataProc) =
   ## Returns the current key using the provided `onData` callback.
@@ -133,9 +132,8 @@ template key*(iter: RocksIteratorRef, asOpenArray: static bool = false): auto =
     @(iter.keyOpenArray())
 
 template valueOpenArray(iter: RocksIteratorRef): openArray[byte] =
-  var vLen: csize_t
-  let vData = rocksdb_iter_value(iter.cPtr, vLen.addr)
-  toOpenArray(vData, vLen)
+  let vSlice = rocksdb_iter_value_slice(iter.cPtr)
+  toOpenArray(vSlice.data, vSlice.size)
 
 proc value*(iter: RocksIteratorRef, onData: DataProc) =
   ## Returns the current value using the provided `onData` callback.
@@ -185,15 +183,13 @@ iterator pairs*(
 
 func keySlice(iter: RocksIteratorRef): RocksDbSlice =
   ## Returns the current key as a slice.
-  var kLen: csize_t
-  let kData = rocksdb_iter_key(iter.cPtr, kLen.addr)
-  RocksDbSlice.init(kData, kLen)
+  let kSlice = rocksdb_iter_key_slice(iter.cPtr)
+  RocksDbSlice.init(kSlice.data, kSlice.size)
 
 func valueSlice(iter: RocksIteratorRef): RocksDbSlice =
   ## Returns the current value as a slice.
-  var vLen: csize_t
-  let vData = rocksdb_iter_value(iter.cPtr, vLen.addr)
-  RocksDbSlice.init(vData, vLen)
+  let vSlice = rocksdb_iter_value_slice(iter.cPtr)
+  RocksDbSlice.init(vSlice.data, vSlice.size)
 
 iterator slicePairs*(
     iter: RocksIteratorRef, autoClose: static bool = true

--- a/scripts/generate_wrapper.sh
+++ b/scripts/generate_wrapper.sh
@@ -68,4 +68,6 @@ sed -i ':a;N;$!ba;s/#ifdef _WIN32\
 # generate nim wrapper
 c2nim ${OUTPUT_HEADER_FILE} --out:"${C2NIM_GENERATED_WRAPPER}"
 
+sed -i 's/{.bycopy.}//g' "${C2NIM_GENERATED_WRAPPER}"
+
 nimble format

--- a/tests/test_columnfamily.nim
+++ b/tests/test_columnfamily.nim
@@ -192,3 +192,42 @@ suite "ColFamily Tests":
       check:
         i == 3
         iter.isClosed()
+
+  test "Test get into buffer":
+    let cf = db.getColFamily(CF_OTHER).get()
+
+    check cf.put(key, val).isOk()
+
+    # Key found, buffer is exactly the right size
+    var buf = newSeq[byte](val.len)
+    var dataLen = -1
+    let r1 = cf.get(key, buf, dataLen)
+    check:
+      r1.isOk() and r1.value == true
+      dataLen == val.len
+      buf == val
+
+    # Key found, larger buffer also works
+    var bigBuf = newSeq[byte](val.len + 10)
+    dataLen = -1
+    let r2 = cf.get(key, bigBuf, dataLen)
+    check:
+      r2.isOk() and r2.value == true
+      dataLen == val.len
+      bigBuf[0 ..< val.len] == val
+
+    # Key found but buffer too small
+    var smallBuf = newSeq[byte](val.len - 1)
+    dataLen = -1
+    let r3 = cf.get(key, smallBuf, dataLen)
+    check:
+      r3.isErr()
+      dataLen == val.len
+
+    # Key not found
+    var buf2 = newSeq[byte](val.len)
+    dataLen = -1
+    let r4 = cf.get(otherKey, buf2, dataLen)
+    check:
+      r4.isOk() and r4.value == false
+      dataLen == 0

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -687,3 +687,50 @@ suite "RocksDbRef Tests":
       check:
         i == 9
         iter.isClosed()
+
+  test "Test get into buffer":
+    check db.put(key, val).isOk()
+
+    # Key found, buffer is exactly the right size
+    var buf = newSeq[byte](val.len)
+    var dataLen = -1
+    let r1 = db.get(key, buf, dataLen)
+    check:
+      r1.isOk() and r1.value == true
+      dataLen == val.len
+      buf == val
+
+    # Key found, larger buffer also works
+    var bigBuf = newSeq[byte](val.len + 10)
+    dataLen = -1
+    let r2 = db.get(key, bigBuf, dataLen)
+    check:
+      r2.isOk() and r2.value == true
+      dataLen == val.len
+      bigBuf[0 ..< val.len] == val
+
+    # Key found but buffer too small
+    var smallBuf = newSeq[byte](val.len - 1)
+    dataLen = -1
+    let r3 = db.get(key, smallBuf, dataLen)
+    check:
+      r3.isErr()
+      dataLen == val.len
+
+    # Key not found
+    var buf2 = newSeq[byte](val.len)
+    dataLen = -1
+    let r4 = db.get(otherKey, buf2, dataLen)
+    check:
+      r4.isOk() and r4.value == false
+      dataLen == 0
+
+    # With explicit column family handle
+    check db.put(key, val, defaultCfHandle).isOk()
+    var buf3 = newSeq[byte](val.len)
+    dataLen = -1
+    let r5 = db.get(key, buf3, dataLen, defaultCfHandle)
+    check:
+      r5.isOk() and r5.value == true
+      dataLen == val.len
+      buf3 == val

--- a/tests/test_rocksdb_benchmark.nim
+++ b/tests/test_rocksdb_benchmark.nim
@@ -7,7 +7,6 @@
 #
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-
 #   RocksDB Read API Performance Benchmark
 #   ======================================
 #  
@@ -24,10 +23,14 @@
 #     - Sweet spot: batch size 64-128; diminishing returns beyond 128
 #     - Iterator variant slightly faster than multiGet for all batch sizes
 
-
 {.used.}
 
-import std/[algorithm, os, strformat, strutils, times], tempfile, unittest2, ../rocksdb/rocksdb, ./test_helper
+import
+  std/[algorithm, os, strformat, strutils, times],
+  tempfile,
+  unittest2,
+  ../rocksdb/rocksdb,
+  ./test_helper
 
 const benchmarkNameWidth = 52
 
@@ -35,15 +38,14 @@ proc benchmarkLine(name: string, elapsed: float, keyReads: int): string =
   let
     readsPerSecond = keyReads.float / elapsed
     microsecondsPerKey = (elapsed * 1_000_000.0) / keyReads.float
-  "  " &
-    alignLeft(name, benchmarkNameWidth) & " " & align(fmt"{elapsed:.4f}", 10) & " " &
-    align(fmt"{readsPerSecond:.2f}", 14) & " " &
-    align(fmt"{microsecondsPerKey:.4f}", 10)
+  "  " & alignLeft(name, benchmarkNameWidth) & " " & align(fmt"{elapsed:.4f}", 10) & " " &
+    align(fmt"{readsPerSecond:.2f}", 14) & " " & align(
+    fmt"{microsecondsPerKey:.4f}", 10
+  )
 
 proc benchmarkHeader(): string =
-  "  " &
-    alignLeft("benchmark", benchmarkNameWidth) & " " &
-    align("elapsed(s)", 10) & " " & align("reads/s", 14) & " " & align("us/key", 10)
+  "  " & alignLeft("benchmark", benchmarkNameWidth) & " " & align("elapsed(s)", 10) & " " &
+    align("reads/s", 14) & " " & align("us/key", 10)
 
 proc makeKey(i: int): seq[byte] =
   # Encode integer keys as fixed-width bytes so all APIs read identical keys.
@@ -73,15 +75,15 @@ proc runBatchedBench(
     sortedReadKeys: seq[seq[byte]],
     keyReads, batchSize: int,
 ): tuple[
-    multiGetElapsed: float,
-    multiGetIterElapsed: float,
-    multiGetSortedElapsed: float,
-    multiGetIterSortedElapsed: float,
-    multiGetBytes: int64,
-    multiGetIterBytes: int64,
-    multiGetSortedBytes: int64,
-    multiGetIterSortedBytes: int64,
-  ] =
+  multiGetElapsed: float,
+  multiGetIterElapsed: float,
+  multiGetSortedElapsed: float,
+  multiGetIterSortedElapsed: float,
+  multiGetBytes: int64,
+  multiGetIterBytes: int64,
+  multiGetSortedBytes: int64,
+  multiGetIterSortedBytes: int64,
+] =
   var
     multiGetBytes = 0'i64
     multiGetIterBytes = 0'i64
@@ -141,18 +143,12 @@ proc runBatchedBench(
   let multiGetIterSortedElapsed = epochTime() - multiGetIterSortedStart
 
   (
-    multiGetElapsed,
-    multiGetIterElapsed,
-    multiGetSortedElapsed,
-    multiGetIterSortedElapsed,
-    multiGetBytes,
-    multiGetIterBytes,
-    multiGetSortedBytes,
+    multiGetElapsed, multiGetIterElapsed, multiGetSortedElapsed,
+    multiGetIterSortedElapsed, multiGetBytes, multiGetIterBytes, multiGetSortedBytes,
     multiGetIterSortedBytes,
   )
 
 suite "RocksDb Benchmark Tests":
-
   test "Benchmark get APIs":
     const
       keyCount = 16_384
@@ -187,9 +183,8 @@ suite "RocksDb Benchmark Tests":
 
     let asyncReadOpts = defaultReadOptions(autoClose = true)
     asyncReadOpts.asyncIo = true
-    let asyncReadDb = openRocksDbReadOnly(benchmarkPath, readOpts = asyncReadOpts).expect(
-      "open async benchmark db"
-    )
+    let asyncReadDb = openRocksDbReadOnly(benchmarkPath, readOpts = asyncReadOpts)
+      .expect("open async benchmark db")
     defer:
       asyncReadDb.close()
 
@@ -275,7 +270,8 @@ suite "RocksDb Benchmark Tests":
     debugEcho benchmarkHeader()
 
     for batchSize in sweepBatchSizes:
-      let sortedSweepKeys = makeSortedReadKeys(keys, sweepIndexes, sweepReadCount, batchSize)
+      let sortedSweepKeys =
+        makeSortedReadKeys(keys, sweepIndexes, sweepReadCount, batchSize)
       let syncResults = runBatchedBench(
         syncReadDb, sweepKeys, sortedSweepKeys, sweepReadCount, batchSize
       )
@@ -295,10 +291,14 @@ suite "RocksDb Benchmark Tests":
         asyncResults.multiGetIterSortedBytes == expectedSweepBytes
 
       debugEcho benchmarkLine(
-        fmt"multiGet(sync, batch={batchSize})", syncResults.multiGetElapsed, sweepReadCount
+        fmt"multiGet(sync, batch={batchSize})",
+        syncResults.multiGetElapsed,
+        sweepReadCount,
       )
       debugEcho benchmarkLine(
-        fmt"multiGet(async, batch={batchSize})", asyncResults.multiGetElapsed, sweepReadCount
+        fmt"multiGet(async, batch={batchSize})",
+        asyncResults.multiGetElapsed,
+        sweepReadCount,
       )
       debugEcho benchmarkLine(
         fmt"multiGetIter(sync, batch={batchSize})",

--- a/tests/test_rocksdb_benchmark.nim
+++ b/tests/test_rocksdb_benchmark.nim
@@ -1,0 +1,332 @@
+# Nim-RocksDB
+# Copyright 2018-2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+
+#   RocksDB Read API Performance Benchmark
+#   ======================================
+#  
+#   Benchmark Summary (16,384 keys × 128-byte values, up to 1M reads):
+#  
+#   Single-key reads (1M operations):
+#     - get(callback):     ~0.82 us/key (~1.2M reads/sec)
+#     - get(seq return):   ~1.46 us/key (~0.7M reads/sec)
+#     - get(into buffer):  ~0.81 us/key (~1.2M reads/sec)
+#  
+#   Batched reads (400K operations, batch-size sweep):
+#     - Best performer: multiGetIter(sorted) at batch=128/256 (~0.72-0.74 us/key)
+#     - Async I/O: Modest but consistent gains in unsorted batched reads
+#     - Sweet spot: batch size 64-128; diminishing returns beyond 128
+#     - Iterator variant slightly faster than multiGet for all batch sizes
+
+
+{.used.}
+
+import std/[algorithm, os, strformat, strutils, times], tempfile, unittest2, ../rocksdb/rocksdb, ./test_helper
+
+const benchmarkNameWidth = 52
+
+proc benchmarkLine(name: string, elapsed: float, keyReads: int): string =
+  let
+    readsPerSecond = keyReads.float / elapsed
+    microsecondsPerKey = (elapsed * 1_000_000.0) / keyReads.float
+  "  " &
+    alignLeft(name, benchmarkNameWidth) & " " & align(fmt"{elapsed:.4f}", 10) & " " &
+    align(fmt"{readsPerSecond:.2f}", 14) & " " &
+    align(fmt"{microsecondsPerKey:.4f}", 10)
+
+proc benchmarkHeader(): string =
+  "  " &
+    alignLeft("benchmark", benchmarkNameWidth) & " " &
+    align("elapsed(s)", 10) & " " & align("reads/s", 14) & " " & align("us/key", 10)
+
+proc makeKey(i: int): seq[byte] =
+  # Encode integer keys as fixed-width bytes so all APIs read identical keys.
+  @[
+    byte((i shr 24) and 0xFF),
+    byte((i shr 16) and 0xFF),
+    byte((i shr 8) and 0xFF),
+    byte(i and 0xFF),
+  ]
+
+proc makeSortedReadKeys(
+    keys: seq[seq[byte]], readIndexes: seq[int], keyReads, batchSize: int
+): seq[seq[byte]] =
+  result = newSeq[seq[byte]](keyReads)
+  var batchStart = 0
+  while batchStart < keyReads:
+    let batchEnd = min(batchStart + batchSize, keyReads)
+    var batchIndexes = readIndexes[batchStart ..< batchEnd]
+    batchIndexes.sort()
+    for offset, index in batchIndexes:
+      result[batchStart + offset] = keys[index]
+    batchStart = batchEnd
+
+proc runBatchedBench(
+    readDb: RocksDbRef,
+    readKeys: seq[seq[byte]],
+    sortedReadKeys: seq[seq[byte]],
+    keyReads, batchSize: int,
+): tuple[
+    multiGetElapsed: float,
+    multiGetIterElapsed: float,
+    multiGetSortedElapsed: float,
+    multiGetIterSortedElapsed: float,
+    multiGetBytes: int64,
+    multiGetIterBytes: int64,
+    multiGetSortedBytes: int64,
+    multiGetIterSortedBytes: int64,
+  ] =
+  var
+    multiGetBytes = 0'i64
+    multiGetIterBytes = 0'i64
+    multiGetSortedBytes = 0'i64
+    multiGetIterSortedBytes = 0'i64
+    batchStart = 0
+
+  let multiGetStart = epochTime()
+  while batchStart < keyReads:
+    let batchEnd = min(batchStart + batchSize, keyReads)
+    let res = readDb.multiGet(readKeys.toOpenArray(batchStart, batchEnd - 1))
+    check res.isOk()
+    for valueOpt in res.value():
+      check valueOpt.isSome()
+      multiGetBytes += int64(valueOpt.get().len)
+    batchStart = batchEnd
+  let multiGetElapsed = epochTime() - multiGetStart
+
+  batchStart = 0
+  let multiGetIterStart = epochTime()
+  while batchStart < keyReads:
+    let batchEnd = min(batchStart + batchSize, keyReads)
+    let res = readDb.multiGetIter(readKeys.toOpenArray(batchStart, batchEnd - 1))
+    check res.isOk()
+    for valueOpt in res.value():
+      check valueOpt.isSome()
+      multiGetIterBytes += int64(valueOpt.get().data().len)
+    batchStart = batchEnd
+  let multiGetIterElapsed = epochTime() - multiGetIterStart
+
+  batchStart = 0
+  let multiGetSortedStart = epochTime()
+  while batchStart < keyReads:
+    let batchEnd = min(batchStart + batchSize, keyReads)
+    let res = readDb.multiGet(
+      sortedReadKeys.toOpenArray(batchStart, batchEnd - 1), sortedInput = true
+    )
+    check res.isOk()
+    for valueOpt in res.value():
+      check valueOpt.isSome()
+      multiGetSortedBytes += int64(valueOpt.get().len)
+    batchStart = batchEnd
+  let multiGetSortedElapsed = epochTime() - multiGetSortedStart
+
+  batchStart = 0
+  let multiGetIterSortedStart = epochTime()
+  while batchStart < keyReads:
+    let batchEnd = min(batchStart + batchSize, keyReads)
+    let res = readDb.multiGetIter(
+      sortedReadKeys.toOpenArray(batchStart, batchEnd - 1), sortedInput = true
+    )
+    check res.isOk()
+    for valueOpt in res.value():
+      check valueOpt.isSome()
+      multiGetIterSortedBytes += int64(valueOpt.get().data().len)
+    batchStart = batchEnd
+  let multiGetIterSortedElapsed = epochTime() - multiGetIterSortedStart
+
+  (
+    multiGetElapsed,
+    multiGetIterElapsed,
+    multiGetSortedElapsed,
+    multiGetIterSortedElapsed,
+    multiGetBytes,
+    multiGetIterBytes,
+    multiGetSortedBytes,
+    multiGetIterSortedBytes,
+  )
+
+suite "RocksDb Benchmark Tests":
+
+  test "Benchmark get APIs":
+    const
+      keyCount = 16_384
+      readCount = 1_000_000
+      sweepReadCount = 400_000
+      valueSize = 128
+      warmupBatchSize = 32
+      sweepBatchSizes = [8, 16, 32, 64, 128, 256]
+
+    let benchmarkPath = mkdtemp() / "benchmark"
+    defer:
+      removeDir(benchmarkPath)
+
+    let writeDb = initReadWriteDb(benchmarkPath)
+
+    var keys = newSeq[seq[byte]](keyCount)
+    for i in 0 ..< keyCount:
+      keys[i] = makeKey(i)
+
+      var value = newSeq[byte](valueSize)
+      for j in 0 ..< valueSize:
+        value[j] = byte((i + j) and 0xFF)
+
+      check writeDb.put(keys[i], value).isOk()
+
+    check writeDb.flush().isOk()
+    writeDb.close()
+
+    let syncReadDb = openRocksDbReadOnly(benchmarkPath).expect("open sync benchmark db")
+    defer:
+      syncReadDb.close()
+
+    let asyncReadOpts = defaultReadOptions(autoClose = true)
+    asyncReadOpts.asyncIo = true
+    let asyncReadDb = openRocksDbReadOnly(benchmarkPath, readOpts = asyncReadOpts).expect(
+      "open async benchmark db"
+    )
+    defer:
+      asyncReadDb.close()
+
+    var
+      readKeys = newSeq[seq[byte]](readCount)
+      readIndexes = newSeq[int](readCount)
+    for i in 0 ..< readCount:
+      let index = ((i * 2654435761'i64) mod keyCount.int64).int
+      readIndexes[i] = index
+      readKeys[i] = keys[index]
+
+    let
+      sweepIndexes = readIndexes[0 ..< sweepReadCount]
+      sweepKeys = readKeys[0 ..< sweepReadCount]
+
+    # Warm-up to reduce one-off effects (cache and initialization noise).
+    block:
+      var warmupBytes = 0'i64
+      for i in 0 ..< min(readCount, 20_000):
+        let res = syncReadDb.get(readKeys[i])
+        check res.isOk()
+        warmupBytes += int64(res.value().len)
+      check warmupBytes > 0
+
+    block:
+      var warmupBytes = 0'i64
+      var batchStart = 0
+      while batchStart < min(readCount, 20_000):
+        let batchEnd = min(batchStart + warmupBatchSize, min(readCount, 20_000))
+        let res = asyncReadDb.multiGet(readKeys.toOpenArray(batchStart, batchEnd - 1))
+        check res.isOk()
+        for valueOpt in res.value():
+          check valueOpt.isSome()
+          warmupBytes += int64(valueOpt.get().len)
+        batchStart = batchEnd
+      check warmupBytes > 0
+
+    var
+      callbackBytes = 0'i64
+      seqGetBytes = 0'i64
+      bufferGetBytes = 0'i64
+
+    let callbackStart = epochTime()
+    for key in readKeys:
+      let res = syncReadDb.get(
+        key,
+        proc(data: openArray[byte]) =
+          callbackBytes += int64(data.len),
+      )
+      check:
+        res.isOk()
+        res.value() == true
+    let callbackElapsed = epochTime() - callbackStart
+
+    let seqGetStart = epochTime()
+    for key in readKeys:
+      let res = syncReadDb.get(key)
+      check res.isOk()
+      seqGetBytes += int64(res.value().len)
+    let seqGetElapsed = epochTime() - seqGetStart
+
+    var buffer = newSeq[byte](valueSize)
+    var dataLen = -1
+    let bufferGetStart = epochTime()
+    for key in readKeys:
+      let res = syncReadDb.get(key, buffer, dataLen)
+      check:
+        res.isOk()
+        res.value() == true
+      bufferGetBytes += int64(dataLen)
+    let bufferGetElapsed = epochTime() - bufferGetStart
+
+    check:
+      callbackBytes == seqGetBytes
+      callbackBytes == bufferGetBytes
+
+    debugEcho "RocksDB get benchmark (single-threaded):"
+    debugEcho benchmarkHeader()
+    debugEcho benchmarkLine("get(callback)", callbackElapsed, readCount)
+    debugEcho benchmarkLine("get(seq return)", seqGetElapsed, readCount)
+    debugEcho benchmarkLine("get(into buffer)", bufferGetElapsed, readCount)
+    debugEcho "RocksDB batched read sweep (single-threaded):"
+    debugEcho benchmarkHeader()
+
+    for batchSize in sweepBatchSizes:
+      let sortedSweepKeys = makeSortedReadKeys(keys, sweepIndexes, sweepReadCount, batchSize)
+      let syncResults = runBatchedBench(
+        syncReadDb, sweepKeys, sortedSweepKeys, sweepReadCount, batchSize
+      )
+      let asyncResults = runBatchedBench(
+        asyncReadDb, sweepKeys, sortedSweepKeys, sweepReadCount, batchSize
+      )
+      let expectedSweepBytes = int64(sweepReadCount * valueSize)
+
+      check:
+        syncResults.multiGetBytes == expectedSweepBytes
+        syncResults.multiGetIterBytes == expectedSweepBytes
+        syncResults.multiGetSortedBytes == expectedSweepBytes
+        syncResults.multiGetIterSortedBytes == expectedSweepBytes
+        asyncResults.multiGetBytes == expectedSweepBytes
+        asyncResults.multiGetIterBytes == expectedSweepBytes
+        asyncResults.multiGetSortedBytes == expectedSweepBytes
+        asyncResults.multiGetIterSortedBytes == expectedSweepBytes
+
+      debugEcho benchmarkLine(
+        fmt"multiGet(sync, batch={batchSize})", syncResults.multiGetElapsed, sweepReadCount
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGet(async, batch={batchSize})", asyncResults.multiGetElapsed, sweepReadCount
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGetIter(sync, batch={batchSize})",
+        syncResults.multiGetIterElapsed,
+        sweepReadCount,
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGetIter(async, batch={batchSize})",
+        asyncResults.multiGetIterElapsed,
+        sweepReadCount,
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGet(sync, sorted, batch={batchSize})",
+        syncResults.multiGetSortedElapsed,
+        sweepReadCount,
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGet(async, sorted, batch={batchSize})",
+        asyncResults.multiGetSortedElapsed,
+        sweepReadCount,
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGetIter(sync, sorted, batch={batchSize})",
+        syncResults.multiGetIterSortedElapsed,
+        sweepReadCount,
+      )
+      debugEcho benchmarkLine(
+        fmt"multiGetIter(async, sorted, batch={batchSize})",
+        asyncResults.multiGetIterSortedElapsed,
+        sweepReadCount,
+      )


### PR DESCRIPTION
- multiGet functions updated to use the new `rocksdb_batched_multi_get_cf_slice` function passing in the new slice type.
- iterators are updated to use the new slice functions when fetching keys and values.
- The existing get function updated to use the new `rocksdb_get_pinned_cf_v2` which reduces the number of copies when fetching.
- Added a new get function which writes the returned value directly into a buffer.
