### PR TITLE
Add wrapper for the hyper clock cache 

### DIFF
--- a/rocksdb/options/cache.nim
+++ b/rocksdb/options/cache.nim
@@ -14,8 +14,7 @@ proc cacheCreateHyperClock*(
     size: int, estimatedEntryCharge: int = 0, autoClose = false
 ): CacheRef =
   CacheRef(
-    cPtr:
-      rocksdb_cache_create_hyper_clock(size.csize_t, estimatedEntryCharge.csize_t),
+    cPtr: rocksdb_cache_create_hyper_clock(size.csize_t, estimatedEntryCharge.csize_t),
     autoClose: autoClose,
   )
 

--- a/rocksdb/options/cache.nim
+++ b/rocksdb/options/cache.nim
@@ -10,6 +10,15 @@ type
 proc cacheCreateLRU*(size: int, autoClose = false): CacheRef =
   CacheRef(cPtr: rocksdb_cache_create_lru(size.csize_t), autoClose: autoClose)
 
+proc cacheCreateHyperClock*(
+    capacity: int, estimatedEntryCharge: int = 0, autoClose = false
+): CacheRef =
+  CacheRef(
+    cPtr:
+      rocksdb_cache_create_hyper_clock(capacity.csize_t, estimatedEntryCharge.csize_t),
+    autoClose: autoClose,
+  )
+
 proc isClosed*(cache: CacheRef): bool =
   isNil(cache.cPtr)
 

--- a/rocksdb/options/cache.nim
+++ b/rocksdb/options/cache.nim
@@ -11,11 +11,11 @@ proc cacheCreateLRU*(size: int, autoClose = false): CacheRef =
   CacheRef(cPtr: rocksdb_cache_create_lru(size.csize_t), autoClose: autoClose)
 
 proc cacheCreateHyperClock*(
-    capacity: int, estimatedEntryCharge: int = 0, autoClose = false
+    size: int, estimatedEntryCharge: int = 0, autoClose = false
 ): CacheRef =
   CacheRef(
     cPtr:
-      rocksdb_cache_create_hyper_clock(capacity.csize_t, estimatedEntryCharge.csize_t),
+      rocksdb_cache_create_hyper_clock(size.csize_t, estimatedEntryCharge.csize_t),
     autoClose: autoClose,
   )
 

--- a/tests/options/test_cache.nim
+++ b/tests/options/test_cache.nim
@@ -1,0 +1,48 @@
+# Nim-RocksDB
+# Copyright 2024 Status Research & Development GmbH
+# Licensed under either of
+#
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+#  * GPL license, version 2.0, ([LICENSE-GPLv2](LICENSE-GPLv2) or https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+#
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import unittest2, ../../rocksdb/options/cache
+
+suite "CacheRef Tests":
+  test "Test cacheCreateLRU":
+    let cache = cacheCreateLRU(1024 * 1024)
+    check not cache.isClosed()
+    cache.close()
+    check cache.isClosed()
+
+  test "Test cacheCreateLRU close idempotent":
+    let cache = cacheCreateLRU(1024 * 1024)
+    cache.close()
+    cache.close()
+    check cache.isClosed()
+
+  test "Test cacheCreateHyperClock default (auto charge)":
+    let cache = cacheCreateHyperClock(1024 * 1024)
+    check not cache.isClosed()
+    cache.close()
+    check cache.isClosed()
+
+  test "Test cacheCreateHyperClock explicit entry charge":
+    let cache = cacheCreateHyperClock(1024 * 1024, estimatedEntryCharge = 8192)
+    check not cache.isClosed()
+    cache.close()
+    check cache.isClosed()
+
+  test "Test cacheCreateHyperClock close idempotent":
+    let cache = cacheCreateHyperClock(1024 * 1024)
+    cache.close()
+    cache.close()
+    check cache.isClosed()
+
+  test "Test autoClose flag is stored":
+    let cache = cacheCreateHyperClock(1024 * 1024, autoClose = true)
+    check cache.autoClose == true
+    cache.close()

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -14,6 +14,7 @@ import
   ./internal/test_cftable,
   ./lib/test_librocksdb,
   ./options/test_backupopts,
+  ./options/test_cache,
   ./options/test_dbopts,
   ./options/test_readopts,
   ./options/test_tableopts,

--- a/tests/test_rocksdb.nim
+++ b/tests/test_rocksdb.nim
@@ -688,6 +688,50 @@ suite "RocksDbRef Tests":
         i == 9
         iter.isClosed()
 
+  test "Test block cache with LRU cache":
+    let
+      dbPath2 = mkdtemp() / "lru-block-cache"
+      tableOpts = defaultTableOptions(autoClose = true)
+      cache = cacheCreateLRU(1024 * 1024, autoClose = true)
+      cfOpts = defaultColFamilyOptions(autoClose = true)
+
+    tableOpts.blockCache = cache
+    cfOpts.blockBasedTableFactory = tableOpts
+
+    let db2 = openRocksDb(
+        dbPath2, columnFamilies = @[initColFamilyDescriptor(CF_DEFAULT, cfOpts)]
+      )
+      .get()
+
+    check:
+      db2.put(key, val).isOk()
+      db2.get(key).get() == val
+
+    db2.close()
+    removeDir($dbPath2)
+
+  test "Test block cache with HyperClockCache":
+    let
+      dbPath2 = mkdtemp() / "hyper-clock-cache"
+      tableOpts = defaultTableOptions(autoClose = true)
+      cache = cacheCreateHyperClock(1024 * 1024, autoClose = true)
+      cfOpts = defaultColFamilyOptions(autoClose = true)
+
+    tableOpts.blockCache = cache
+    cfOpts.blockBasedTableFactory = tableOpts
+
+    let db2 = openRocksDb(
+        dbPath2, columnFamilies = @[initColFamilyDescriptor(CF_DEFAULT, cfOpts)]
+      )
+      .get()
+
+    check:
+      db2.put(key, val).isOk()
+      db2.get(key).get() == val
+
+    db2.close()
+    removeDir($dbPath2)
+
   test "Test get into buffer":
     check db.put(key, val).isOk()
 


### PR DESCRIPTION
The hyper clock cache may improve performance for multi-threaded workloads. It is now generally recommended over the lru block cache. See here: https://github.com/facebook/rocksdb/blob/4595a5e95ae8525c42e172a054435782b3479c57/include/rocksdb/cache.h#L382

